### PR TITLE
docs: don't close a bead until its PR is merged

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,6 +13,13 @@ You must only inform the user that the PR is opened.
    If even needed, do it in a temporary location only.
 5. Don't install any additional binaries or libraries on the system.
 
+## Issue tracking (beads)
+
+1. Every code change maps to a bead.
+2. Don't close a bead until its PR is merged to `main`.
+3. When you open the PR, set the bead to `in_progress` and link the PR in a note.
+4. Close the bead only after the merge lands.
+
 ## Dependency upgrade PRs
 
 1. Every dependency upgrade change must have the `npx --yes package-lock-utd@1.1.3`


### PR DESCRIPTION
## What

Adds an **Issue tracking (beads)** section to `AGENTS.md` capturing the rule: a bead must stay open until its PR is merged.

## Why

While implementing the knowledge-map work I closed the bead as soon as the PR was opened — before it merged. This rule prevents that: the bead stays `in_progress` during review and is closed only after the merge lands.

## Rule added

1. Every code change maps to a bead.
2. Don't close a bead until its PR is merged to `main`.
3. When you open the PR, set the bead to `in_progress` and link the PR in a note.
4. Close the bead only after the merge lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)