### PR TITLE
fix: knip 6.27.0 bump passes CI

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -25,7 +25,7 @@
                 "eslint": "^9.39.3",
                 "eslint-plugin-markdownlint": "^0.10.1",
                 "eslint-plugin-react": "^7.37.5",
-                "knip": "^6.17.1",
+                "knip": "^6.27.0",
                 "lucide-react": "^1.21.0",
                 "postcss": "^8.5.15",
                 "prettier": "^3.9.6",
@@ -4493,21 +4493,21 @@
             }
         },
         "node_modules/@emnapi/core": {
-            "version": "1.10.0",
-            "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
-            "integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
+            "version": "1.11.1",
+            "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.11.1.tgz",
+            "integrity": "sha512-RSvbQmHzdKzNsLYa/wHrbc3KN4sYLKAdPZxqiM2HATqv/SBk2/ENSHpvXGaLOMcsAyz0poEGqkmmKYG3OWiJEQ==",
             "dev": true,
             "license": "MIT",
             "optional": true,
             "dependencies": {
-                "@emnapi/wasi-threads": "1.2.1",
+                "@emnapi/wasi-threads": "1.2.2",
                 "tslib": "^2.4.0"
             }
         },
         "node_modules/@emnapi/runtime": {
-            "version": "1.10.0",
-            "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
-            "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
+            "version": "1.11.1",
+            "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.1.tgz",
+            "integrity": "sha512-vgj7R3y3Wgx24IQaGPA/R6YFXLHVMOZ0uVEyIQPaWs+rd1AzfEMXlAC22FYwO1XkKR6NPsq7mUandH8oIRdZFw==",
             "dev": true,
             "license": "MIT",
             "optional": true,
@@ -4516,9 +4516,9 @@
             }
         },
         "node_modules/@emnapi/wasi-threads": {
-            "version": "1.2.1",
-            "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",
-            "integrity": "sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==",
+            "version": "1.2.2",
+            "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.2.tgz",
+            "integrity": "sha512-c95qOXkHdydNKhscBTebqEC1CVAZpyqOfVfBzQ1qgzyl3gfeldUjIggDbIZgDKsHLgnsM+igH7TJ/eAasaVuMA==",
             "dev": true,
             "license": "MIT",
             "optional": true,
@@ -5355,14 +5355,14 @@
             }
         },
         "node_modules/@napi-rs/wasm-runtime": {
-            "version": "1.1.4",
-            "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.4.tgz",
-            "integrity": "sha512-3NQNNgA1YSlJb/kMH1ildASP9HW7/7kYnRI2szWJaofaS1hWmbGI4H+d3+22aGzXXN9IJ+n+GiFVcGipJP18ow==",
+            "version": "1.1.6",
+            "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.6.tgz",
+            "integrity": "sha512-ZLv/JdUfkvOy9eCnnBaGfiO+XimbjebAeO+MRQqD/B+FR1tnRN0tpKSJHRbE8sFfS6aqsXZ67TQjfwfsxULVbg==",
             "dev": true,
             "license": "MIT",
             "optional": true,
             "dependencies": {
-                "@tybys/wasm-util": "^0.10.1"
+                "@tybys/wasm-util": "^0.10.3"
             },
             "funding": {
                 "type": "github",
@@ -5425,9 +5425,9 @@
             }
         },
         "node_modules/@oxc-parser/binding-android-arm-eabi": {
-            "version": "0.135.0",
-            "resolved": "https://registry.npmjs.org/@oxc-parser/binding-android-arm-eabi/-/binding-android-arm-eabi-0.135.0.tgz",
-            "integrity": "sha512-sHeZItACNcA5WRAWqF6ixriR4GkZDyY10gVgnZU7pXku1DjHFATSqnwZM809jl0gXPHxb6fKzYQCK7bNK5cACQ==",
+            "version": "0.137.0",
+            "resolved": "https://registry.npmjs.org/@oxc-parser/binding-android-arm-eabi/-/binding-android-arm-eabi-0.137.0.tgz",
+            "integrity": "sha512-KDs+0VPdEmasOkpuJHW9V5WCF+cvYdMQv2Jd+aJXt+cxIx12NToRQRbXaRwUEDsZw+/jMk81Ve8ZFbjUkJTOwA==",
             "cpu": [
                 "arm"
             ],
@@ -5442,9 +5442,9 @@
             }
         },
         "node_modules/@oxc-parser/binding-android-arm64": {
-            "version": "0.135.0",
-            "resolved": "https://registry.npmjs.org/@oxc-parser/binding-android-arm64/-/binding-android-arm64-0.135.0.tgz",
-            "integrity": "sha512-wPte+SzgzWWFgMSF8YZDNM+tBXtJg0AXBi7+tU3yS2z1f2Af9kRLZLKuJojADmuD/cZexmnMHHC3SDItTW77Iw==",
+            "version": "0.137.0",
+            "resolved": "https://registry.npmjs.org/@oxc-parser/binding-android-arm64/-/binding-android-arm64-0.137.0.tgz",
+            "integrity": "sha512-WhALNzfy3x/RfC6bsqX+csavuUY0yHHE7XfgPE5M542uhoBZUUoGTPG+nkMbGoG4+gcfss5s7urMyn5QBHu0sw==",
             "cpu": [
                 "arm64"
             ],
@@ -5459,9 +5459,9 @@
             }
         },
         "node_modules/@oxc-parser/binding-darwin-arm64": {
-            "version": "0.135.0",
-            "resolved": "https://registry.npmjs.org/@oxc-parser/binding-darwin-arm64/-/binding-darwin-arm64-0.135.0.tgz",
-            "integrity": "sha512-BmKz3lHIsqVos+9aPcdYCT9MG3APoUyM43KlEFhJMWNVDOGG8FKyiFz81Bc+mGz2o0hpuQ3PfXLfVWJrKXjo2g==",
+            "version": "0.137.0",
+            "resolved": "https://registry.npmjs.org/@oxc-parser/binding-darwin-arm64/-/binding-darwin-arm64-0.137.0.tgz",
+            "integrity": "sha512-bFPr5hgmNMOMoyPTGtdsK4Ug21RovIPojRMgDDhSp1LtCnc/DkLwGONKjgRjszg677RlGnkYSviQ8hHaUPOVYA==",
             "cpu": [
                 "arm64"
             ],
@@ -5476,9 +5476,9 @@
             }
         },
         "node_modules/@oxc-parser/binding-darwin-x64": {
-            "version": "0.135.0",
-            "resolved": "https://registry.npmjs.org/@oxc-parser/binding-darwin-x64/-/binding-darwin-x64-0.135.0.tgz",
-            "integrity": "sha512-dM8BS+8+Br1fNvmh2QZbGiHaYttwLebRa6J4Uz9vuFzMNmvsdRYwf7993ptOaV0JTrR63AaoVLjX7nhWbijxjQ==",
+            "version": "0.137.0",
+            "resolved": "https://registry.npmjs.org/@oxc-parser/binding-darwin-x64/-/binding-darwin-x64-0.137.0.tgz",
+            "integrity": "sha512-CL5dMm1asqXIDZHg14FLxj3Mc36w8PI7xCWh1uA4is6z8g2XrIILoTcQYOxDbwzuk34RDPX5IAGUxZr6LA9KAg==",
             "cpu": [
                 "x64"
             ],
@@ -5493,9 +5493,9 @@
             }
         },
         "node_modules/@oxc-parser/binding-freebsd-x64": {
-            "version": "0.135.0",
-            "resolved": "https://registry.npmjs.org/@oxc-parser/binding-freebsd-x64/-/binding-freebsd-x64-0.135.0.tgz",
-            "integrity": "sha512-xlZnvvJdR9bGu2pOhvR5hMuKPHCE6Sa9owK5A484mzjHdm75VRV5nCs5w/jkmGODMMTFc+KN7EnZqEieM813kw==",
+            "version": "0.137.0",
+            "resolved": "https://registry.npmjs.org/@oxc-parser/binding-freebsd-x64/-/binding-freebsd-x64-0.137.0.tgz",
+            "integrity": "sha512-79h8rYGnSlKPGWo7mHr2ixO6ea7aW8B0CT965SZ8SLbNnCOH5aOYBTeVXUY6eMvEaiLyWr8Skuiugr5pDYgLGw==",
             "cpu": [
                 "x64"
             ],
@@ -5510,9 +5510,9 @@
             }
         },
         "node_modules/@oxc-parser/binding-linux-arm-gnueabihf": {
-            "version": "0.135.0",
-            "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-0.135.0.tgz",
-            "integrity": "sha512-PSR8LmBK/H/PQRiN8g7RebQgZX/ntVCrdT/JBfNxE5ezdHG1s2i4rbazsRJYD83TTI1MmgTpC0MGL42PLtskQQ==",
+            "version": "0.137.0",
+            "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-0.137.0.tgz",
+            "integrity": "sha512-ASgmlSimhGyr0lksgVIo6hibz1obnDq4qJbiMX/AzltfgPnanRrzG1Q+23g8ljOHOjv6dsznkUuCYL3gg0sY1Q==",
             "cpu": [
                 "arm"
             ],
@@ -5527,9 +5527,9 @@
             }
         },
         "node_modules/@oxc-parser/binding-linux-arm-musleabihf": {
-            "version": "0.135.0",
-            "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-arm-musleabihf/-/binding-linux-arm-musleabihf-0.135.0.tgz",
-            "integrity": "sha512-I85GJXzfUsigkkk7Ngdz95C217M4FdUi1Z2HrX5UyPmURobwQZ7m2bbUvwFkz4VGZd+lymFGKHvDZ3RQC9qOzA==",
+            "version": "0.137.0",
+            "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-arm-musleabihf/-/binding-linux-arm-musleabihf-0.137.0.tgz",
+            "integrity": "sha512-AU2J9aa22Sx32wRGnDjybOU9TQXXQUud5sdUi+ZB0XxwM8aToWLweV+yA0wlQm0yIUVqljquqoHCYEq9II8gJQ==",
             "cpu": [
                 "arm"
             ],
@@ -5544,9 +5544,9 @@
             }
         },
         "node_modules/@oxc-parser/binding-linux-arm64-gnu": {
-            "version": "0.135.0",
-            "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-0.135.0.tgz",
-            "integrity": "sha512-zqEY0npz0g0aGZj/8a5BclunjVDytsBQHYtIC10Gd26HcrLwbVF6YDbqRQjunMGYdSo97u6xOBl05aTDI2diDQ==",
+            "version": "0.137.0",
+            "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-0.137.0.tgz",
+            "integrity": "sha512-GdEtiG89yMr7XkUGxifgodXEEm2f+xW2f9CpDjlgAnBOwhTmrpQMvhOGobLVKUyzf/qHBXW16smk5zbF3nZU6w==",
             "cpu": [
                 "arm64"
             ],
@@ -5561,9 +5561,9 @@
             }
         },
         "node_modules/@oxc-parser/binding-linux-arm64-musl": {
-            "version": "0.135.0",
-            "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-arm64-musl/-/binding-linux-arm64-musl-0.135.0.tgz",
-            "integrity": "sha512-mWAfprP819gQ2qYst1RxgTI8b/z0b29OpoKfRflIXLHde2dZLihQD4g47Onuvtpo5GPIkMYPRlX9QoeZfs/GnQ==",
+            "version": "0.137.0",
+            "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-arm64-musl/-/binding-linux-arm64-musl-0.137.0.tgz",
+            "integrity": "sha512-EGJ+Bs8iXx8KBH8DQ5BLoEm5lnHaYjlh4/8j8vFhrr/6z4tqONy5BZDzLpKmmNWlN6Hlc5r8YOuBVHqZ9vRFEQ==",
             "cpu": [
                 "arm64"
             ],
@@ -5578,9 +5578,9 @@
             }
         },
         "node_modules/@oxc-parser/binding-linux-ppc64-gnu": {
-            "version": "0.135.0",
-            "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-0.135.0.tgz",
-            "integrity": "sha512-gri8c2AOmJKJwOux2KTHFBfUaXoJURuVMKhmKEi/2hTF55cQteTDV2XNfTiE5oCC+Tnem1Y4/MWzcyDadtsSag==",
+            "version": "0.137.0",
+            "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-0.137.0.tgz",
+            "integrity": "sha512-vzFUQENy/fnbSe5DZWovq6tIBc1uhuMztanSW6rz1e9WdQE4gHwYuD7ZII6JnrJifd1R3RSoqiZbgRFlVL2tYQ==",
             "cpu": [
                 "ppc64"
             ],
@@ -5595,9 +5595,9 @@
             }
         },
         "node_modules/@oxc-parser/binding-linux-riscv64-gnu": {
-            "version": "0.135.0",
-            "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-riscv64-gnu/-/binding-linux-riscv64-gnu-0.135.0.tgz",
-            "integrity": "sha512-Y2tkupCG5wo0SxH2rMLG4d4Kmv6DaM3sBp+GuM5lox0S8Za6VxKgQrY2Mut088QQxKkEE89n/4CCCgmw2o0e3Q==",
+            "version": "0.137.0",
+            "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-riscv64-gnu/-/binding-linux-riscv64-gnu-0.137.0.tgz",
+            "integrity": "sha512-SfVI14HBQs9gtLcUD5hTt5hsNbdrqSUNg9S8muN+LhVQ5nf1WwH3hAoK6B9NKgdYgWAQSXFXGiiBedQ4r/BKuw==",
             "cpu": [
                 "riscv64"
             ],
@@ -5612,9 +5612,9 @@
             }
         },
         "node_modules/@oxc-parser/binding-linux-riscv64-musl": {
-            "version": "0.135.0",
-            "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-riscv64-musl/-/binding-linux-riscv64-musl-0.135.0.tgz",
-            "integrity": "sha512-xDRJq6i6WTynjeP+ISbDpyH4p9BaJ0wuQcL0lCSDkt9qOXC9dmwpOu1VG/TlwmPI3KpYntmO9nJCuc3TMTsNBA==",
+            "version": "0.137.0",
+            "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-riscv64-musl/-/binding-linux-riscv64-musl-0.137.0.tgz",
+            "integrity": "sha512-e7Ppy4FCIFNQxT/ikSeIWFoQ0l+N9vgtRBtLcyZXeolTzApyVoPqEXsYPrcdM/9i0Bwk8knvYd37vaEMxHyi6g==",
             "cpu": [
                 "riscv64"
             ],
@@ -5629,9 +5629,9 @@
             }
         },
         "node_modules/@oxc-parser/binding-linux-s390x-gnu": {
-            "version": "0.135.0",
-            "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-0.135.0.tgz",
-            "integrity": "sha512-V4MoUuiCRNvihxhIufRxvK+ka013V4joTSK0FAGA1KEjLuNprfH6N/Qw2uxQEVIFuNYMhD/hV6xJ/ptbzlKdHg==",
+            "version": "0.137.0",
+            "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-0.137.0.tgz",
+            "integrity": "sha512-Bho5qFwdhqsIFR7gipYEUlqvi3SRrY8sugxXig380MIaakBB1PyU9+7dBiBVScfImTNWhijUxdBwqrprGdq5WA==",
             "cpu": [
                 "s390x"
             ],
@@ -5646,9 +5646,9 @@
             }
         },
         "node_modules/@oxc-parser/binding-linux-x64-gnu": {
-            "version": "0.135.0",
-            "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-x64-gnu/-/binding-linux-x64-gnu-0.135.0.tgz",
-            "integrity": "sha512-JCFZ7zM7KXOKoPAbK/ZB4wY0M1jxRECiem2UQuiXLjzGqS9+hno7mtX+qyK2F7HWK2xPhyJb+frpcOtk5DKOtg==",
+            "version": "0.137.0",
+            "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-x64-gnu/-/binding-linux-x64-gnu-0.137.0.tgz",
+            "integrity": "sha512-36mGWtg7PyFzjJwGDkH6/F4o2nIDEoKXLPr/X/lwqklkomQwJJt1I5GJVmGhovUEmgPK5WAeAZMqlFCehwiy9Q==",
             "cpu": [
                 "x64"
             ],
@@ -5663,9 +5663,9 @@
             }
         },
         "node_modules/@oxc-parser/binding-linux-x64-musl": {
-            "version": "0.135.0",
-            "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-x64-musl/-/binding-linux-x64-musl-0.135.0.tgz",
-            "integrity": "sha512-9jSVS1b3hOV7sdKH4aA2DFfnTz0RgQd0v2BefR+LYbH8yIlmSM22JJZbAAjVeVXmFgUAk3zJQ1tpE/Nd+Vi2YQ==",
+            "version": "0.137.0",
+            "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-x64-musl/-/binding-linux-x64-musl-0.137.0.tgz",
+            "integrity": "sha512-/Jqx6+N7A44n2BdvUr7pXhVr2vFjs6WGH3unZRczwrfiH0H1zY0QwKQMG/dtRiTlKGDKGukznPT8lx84/oEsZg==",
             "cpu": [
                 "x64"
             ],
@@ -5680,9 +5680,9 @@
             }
         },
         "node_modules/@oxc-parser/binding-openharmony-arm64": {
-            "version": "0.135.0",
-            "resolved": "https://registry.npmjs.org/@oxc-parser/binding-openharmony-arm64/-/binding-openharmony-arm64-0.135.0.tgz",
-            "integrity": "sha512-M857ZLBSdn1Uy/SJJz5zh0qGu67B4P9omCgXGBU2LLqTzraX6ZjVNaKq5yW1PDw/LgJXDXR/dbZfgmB310f11Q==",
+            "version": "0.137.0",
+            "resolved": "https://registry.npmjs.org/@oxc-parser/binding-openharmony-arm64/-/binding-openharmony-arm64-0.137.0.tgz",
+            "integrity": "sha512-9Uj0qHNNl+OgT1UTGwF7ixIXU6T1u2SbMidmgPy/h1h/fl2gRS6YpAxxY1gwHofcWjoTwkoMFd8xs5Vuj6GOFA==",
             "cpu": [
                 "arm64"
             ],
@@ -5697,9 +5697,9 @@
             }
         },
         "node_modules/@oxc-parser/binding-wasm32-wasi": {
-            "version": "0.135.0",
-            "resolved": "https://registry.npmjs.org/@oxc-parser/binding-wasm32-wasi/-/binding-wasm32-wasi-0.135.0.tgz",
-            "integrity": "sha512-2w6DVcntQZX9U5RhXtgiWb3FLWFB5EcwI1U8yr3htOCJUJjagN4BFUHz/Y/d9ZsumndZ6ByxxWEtbUZNE1bfFw==",
+            "version": "0.137.0",
+            "resolved": "https://registry.npmjs.org/@oxc-parser/binding-wasm32-wasi/-/binding-wasm32-wasi-0.137.0.tgz",
+            "integrity": "sha512-gW2vfkytNGgMVADiuzdvOfw0mWG9za20F/1fCJsif5aBMAvWJTSbpIXbIe0XkOe0VENk+PadpQ7cZgUy2sUJcA==",
             "cpu": [
                 "wasm32"
             ],
@@ -5707,18 +5707,18 @@
             "license": "MIT",
             "optional": true,
             "dependencies": {
-                "@emnapi/core": "1.10.0",
-                "@emnapi/runtime": "1.10.0",
-                "@napi-rs/wasm-runtime": "^1.1.4"
+                "@emnapi/core": "1.11.1",
+                "@emnapi/runtime": "1.11.1",
+                "@napi-rs/wasm-runtime": "^1.1.5"
             },
             "engines": {
                 "node": "^20.19.0 || >=22.12.0"
             }
         },
         "node_modules/@oxc-parser/binding-win32-arm64-msvc": {
-            "version": "0.135.0",
-            "resolved": "https://registry.npmjs.org/@oxc-parser/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-0.135.0.tgz",
-            "integrity": "sha512-rX1U8+IH2Z37EJjDXKa1iifvUQAdba+vZ4Ewj1iaG5eA/QaSybzclCOwtWa0/5BuUQnnK/T2JHUEFrwhL6Ck2Q==",
+            "version": "0.137.0",
+            "resolved": "https://registry.npmjs.org/@oxc-parser/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-0.137.0.tgz",
+            "integrity": "sha512-x+pFANF0yL5uK/6T7lu6SlR5qid6sp//eZXKLq5iNsIE+EQg6EaS8/wsW7E91nXXjpnPhSoMOHXShSVhGRdn8w==",
             "cpu": [
                 "arm64"
             ],
@@ -5733,9 +5733,9 @@
             }
         },
         "node_modules/@oxc-parser/binding-win32-ia32-msvc": {
-            "version": "0.135.0",
-            "resolved": "https://registry.npmjs.org/@oxc-parser/binding-win32-ia32-msvc/-/binding-win32-ia32-msvc-0.135.0.tgz",
-            "integrity": "sha512-9FAisBbH1QICGAjlJobiuKGd/jOuVmyqniWdQMwTa5SkCl6hhuotBCJf1n46B0flYbSOR5TzfV9HZCWSyb3c/Q==",
+            "version": "0.137.0",
+            "resolved": "https://registry.npmjs.org/@oxc-parser/binding-win32-ia32-msvc/-/binding-win32-ia32-msvc-0.137.0.tgz",
+            "integrity": "sha512-sQUqym80PFi6McRsIqfJrSu2JrSClEZIXXD+/FjAFoULEKzOPsldIdFBG96xdX8aVMzCNQ9792FPx3MfkEIrFA==",
             "cpu": [
                 "ia32"
             ],
@@ -5750,9 +5750,9 @@
             }
         },
         "node_modules/@oxc-parser/binding-win32-x64-msvc": {
-            "version": "0.135.0",
-            "resolved": "https://registry.npmjs.org/@oxc-parser/binding-win32-x64-msvc/-/binding-win32-x64-msvc-0.135.0.tgz",
-            "integrity": "sha512-wYF+A2AzJ2n7ul6q+Z2G/ia0S2+8cUp0AgWZzoFvF4WmUcl1P7p+o6se1Gdr5wGnWuF0iAMIkGddrjCarNr2yA==",
+            "version": "0.137.0",
+            "resolved": "https://registry.npmjs.org/@oxc-parser/binding-win32-x64-msvc/-/binding-win32-x64-msvc-0.137.0.tgz",
+            "integrity": "sha512-2AsevxlvNN4WKxpEn3RtqD5zbqMaXF+T7JXblsP4gVuY+vC9dXS4ED/PwfRCliFqoeisYS3Iro4DHzxr0TEvVA==",
             "cpu": [
                 "x64"
             ],
@@ -5767,9 +5767,9 @@
             }
         },
         "node_modules/@oxc-project/types": {
-            "version": "0.135.0",
-            "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.135.0.tgz",
-            "integrity": "sha512-wR+xRdFkUBMvcAjBJ2q2kcZM6d+DKu2NgoOyxZgYwZdLhmiv6+rnO8PZ/P68kMiZtIKm+pW7zyEJ4kSOs0vo+Q==",
+            "version": "0.137.0",
+            "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.137.0.tgz",
+            "integrity": "sha512-WT+Gb24i8hmvo85AIv2oEYouEXkRlKAlT9WaCa3TfLgNCN+GhrJOGZuIlMouAh38Qe4QOx26eUOVsq70qXrywA==",
             "dev": true,
             "license": "MIT",
             "funding": {
@@ -5777,9 +5777,9 @@
             }
         },
         "node_modules/@oxc-resolver/binding-android-arm-eabi": {
-            "version": "11.20.0",
-            "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-android-arm-eabi/-/binding-android-arm-eabi-11.20.0.tgz",
-            "integrity": "sha512-IjfWOXRgJFNdORDl+Uf1aibNgZY2guOD3zmOhx1BGVb/MIiqlFTdmjpQNplSN58lhWehnX4UNqC3QwpUo8pjJg==",
+            "version": "11.21.3",
+            "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-android-arm-eabi/-/binding-android-arm-eabi-11.21.3.tgz",
+            "integrity": "sha512-eNU11A2WNizh04v3uyaJCootrHIaS0B9aHYXvAvVnPNk4xYSjMUjHnhQ6dewPN2MRYDskV85d1N0Aw0WNWhcyg==",
             "cpu": [
                 "arm"
             ],
@@ -5791,9 +5791,9 @@
             ]
         },
         "node_modules/@oxc-resolver/binding-android-arm64": {
-            "version": "11.20.0",
-            "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-android-arm64/-/binding-android-arm64-11.20.0.tgz",
-            "integrity": "sha512-QqslZAuFQG8Q9xm7JuIn8JUbvywhSBMVhuQHtYW+auirZJloS41oxUUaBXk7uUhZJgp44c5zQLeVvmFaDQB+2Q==",
+            "version": "11.21.3",
+            "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-android-arm64/-/binding-android-arm64-11.21.3.tgz",
+            "integrity": "sha512-8Q+ZjTLvn2dIcWsrmhdrEihm7q+ag/k+mkry7Z+t0QbbHaVxXQfvH9AewyVMh/WrpEKhQ3DDgx9fYbqeCpeOEw==",
             "cpu": [
                 "arm64"
             ],
@@ -5805,9 +5805,9 @@
             ]
         },
         "node_modules/@oxc-resolver/binding-darwin-arm64": {
-            "version": "11.20.0",
-            "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-darwin-arm64/-/binding-darwin-arm64-11.20.0.tgz",
-            "integrity": "sha512-MUcavykj2ewlR+kc5arpg4tC2RvzJkUxWtNv74pf7lcNk00GpIpN43vXMj+j6r4eMmfZhlb8hueKoIb8e9kAGQ==",
+            "version": "11.21.3",
+            "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-darwin-arm64/-/binding-darwin-arm64-11.21.3.tgz",
+            "integrity": "sha512-wkh0qKZGHXVUDxFw3oA1TXnU2BDYY/r775oJflGeIr8uDPPoN2pk8gijQIzYRT6hoql/lg3+Tx/SaTn9e2/aGg==",
             "cpu": [
                 "arm64"
             ],
@@ -5819,9 +5819,9 @@
             ]
         },
         "node_modules/@oxc-resolver/binding-darwin-x64": {
-            "version": "11.20.0",
-            "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-darwin-x64/-/binding-darwin-x64-11.20.0.tgz",
-            "integrity": "sha512-BGB16nRUK5Etiv//ihPyzj8Lj1px0mhh4YIfe0FDf045ywknfSm0GEbiRESpr6Q4K82AvnyaRIhhluHByvS4bg==",
+            "version": "11.21.3",
+            "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-darwin-x64/-/binding-darwin-x64-11.21.3.tgz",
+            "integrity": "sha512-HbNc23FAQYbuyDV2vBWMez4u4mrsm5RAkniGZAWqr6lYZ3N4beeqIb776jzwRl8qL2zRhHVXpUj97X0QgogVzg==",
             "cpu": [
                 "x64"
             ],
@@ -5833,9 +5833,9 @@
             ]
         },
         "node_modules/@oxc-resolver/binding-freebsd-x64": {
-            "version": "11.20.0",
-            "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-freebsd-x64/-/binding-freebsd-x64-11.20.0.tgz",
-            "integrity": "sha512-JZgtePaqj3qmD5XFHJaSLWzHRxQu0LaPkdoM1KJXYADvAaa83ijXHclV3ej3CueeW0wxfIAbGCZVP45J0CA7uQ==",
+            "version": "11.21.3",
+            "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-freebsd-x64/-/binding-freebsd-x64-11.21.3.tgz",
+            "integrity": "sha512-K6xNsTUPEUdfrn0+kbMq5nOUB5w1C5pavPQngt4TM2FpN91lP0PBe2srSpamb4d69O7h86oAi/qWX/kZNRSjkw==",
             "cpu": [
                 "x64"
             ],
@@ -5847,9 +5847,9 @@
             ]
         },
         "node_modules/@oxc-resolver/binding-linux-arm-gnueabihf": {
-            "version": "11.20.0",
-            "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-11.20.0.tgz",
-            "integrity": "sha512-hOQ/p3ry3v3SchUBXicrrnszaI/UmYzM4wtS4RGfwgVUX7a+HbyQSzJ5aOzu+o6XZkFkS3ZXN4PZAzhOb77OSg==",
+            "version": "11.21.3",
+            "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-11.21.3.tgz",
+            "integrity": "sha512-VcFmOpcpWX1zoEy8M58tR2M9YxM+Z9RuQhqAx5q0CTmrruaP7Gveejg75hzd/5sg5nk9G3aLALEa3hE2FsmmTQ==",
             "cpu": [
                 "arm"
             ],
@@ -5861,9 +5861,9 @@
             ]
         },
         "node_modules/@oxc-resolver/binding-linux-arm-musleabihf": {
-            "version": "11.20.0",
-            "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-linux-arm-musleabihf/-/binding-linux-arm-musleabihf-11.20.0.tgz",
-            "integrity": "sha512-2ArPksaw0AqeuGBfoS715VF+JvJQAhD2niWgjE5hVO+L+nAfikVQopvngCMX9x4BD8itWoQ3dnikrQyl5Ho5Jg==",
+            "version": "11.21.3",
+            "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-linux-arm-musleabihf/-/binding-linux-arm-musleabihf-11.21.3.tgz",
+            "integrity": "sha512-quVoxFLBy43hWaQbbDtQNRwAX5vX76mv7n64icAtQcJ3eNgVeblqmkupF/hAneNthdqSlnd1sTjb3aQSaDPaCQ==",
             "cpu": [
                 "arm"
             ],
@@ -5875,9 +5875,9 @@
             ]
         },
         "node_modules/@oxc-resolver/binding-linux-arm64-gnu": {
-            "version": "11.20.0",
-            "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-11.20.0.tgz",
-            "integrity": "sha512-0bJnmYFp62JdZ4nVMDUZ/C58BCZOCcqgKtnUlp7L9Ojf/czIN+3j72YlLPeWLkzlr6SlYvIQA4SGV/HyO0d+qg==",
+            "version": "11.21.3",
+            "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-11.21.3.tgz",
+            "integrity": "sha512-X0AqNZgcD07Q4V3RDK18/vYOj/HQT/FnmEFGYS2jTWqY7JO13ryE3TEs3eAIgUJhBnNkpEaiXqz3VK8M7qQhWQ==",
             "cpu": [
                 "arm64"
             ],
@@ -5889,9 +5889,9 @@
             ]
         },
         "node_modules/@oxc-resolver/binding-linux-arm64-musl": {
-            "version": "11.20.0",
-            "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-linux-arm64-musl/-/binding-linux-arm64-musl-11.20.0.tgz",
-            "integrity": "sha512-wKHHzPKZo7Ufhv/Bt6yxT7FOgnIgW4gwXcJUipkShGp68W3wGVqvr1Sr0fY65lN0Oy6y41+g2kIDvkgZaMMUkw==",
+            "version": "11.21.3",
+            "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-linux-arm64-musl/-/binding-linux-arm64-musl-11.21.3.tgz",
+            "integrity": "sha512-YkaQnaKYdbuaXvRt5Qd0GpbihzVnyfR6z1SpYfIUC6RTu4NF7lDKPjVkYb+jRI2gedVO2rVpN35Y6akG6ud4Lw==",
             "cpu": [
                 "arm64"
             ],
@@ -5903,9 +5903,9 @@
             ]
         },
         "node_modules/@oxc-resolver/binding-linux-ppc64-gnu": {
-            "version": "11.20.0",
-            "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-11.20.0.tgz",
-            "integrity": "sha512-RN8goF7Ie0B79L4i4G6OeBocTgSC56vJbQ65VJje+oXnldVpLnOU7j/AQ/dP94TcCS+Yh6WG8u3Qt4ETteXFNQ==",
+            "version": "11.21.3",
+            "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-11.21.3.tgz",
+            "integrity": "sha512-gB9HwhrPiFqUzDeEq+y/CgAijz1YdI6BnXz5GaH2Pa9cWdutchlkGFAiAuGb/PjVQpiK6NFKzFuztxrweoit7A==",
             "cpu": [
                 "ppc64"
             ],
@@ -5917,9 +5917,9 @@
             ]
         },
         "node_modules/@oxc-resolver/binding-linux-riscv64-gnu": {
-            "version": "11.20.0",
-            "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-linux-riscv64-gnu/-/binding-linux-riscv64-gnu-11.20.0.tgz",
-            "integrity": "sha512-5l1yU6/xQEqLZRzxqmMxJfWPslpwCmBsdDGaBvABPehxquCXDC7dd7oraNdKSJUMDXSM7VvVj8H2D2FTjU7oWw==",
+            "version": "11.21.3",
+            "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-linux-riscv64-gnu/-/binding-linux-riscv64-gnu-11.21.3.tgz",
+            "integrity": "sha512-zjDWBlYk8QGv0H8dsPUWqkfjYIIjG2TvspGkzXL0eImbgxtZorA/klKeHyolevoT3Kvbi+1iMr9Lhrh7jf54Og==",
             "cpu": [
                 "riscv64"
             ],
@@ -5931,9 +5931,9 @@
             ]
         },
         "node_modules/@oxc-resolver/binding-linux-riscv64-musl": {
-            "version": "11.20.0",
-            "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-linux-riscv64-musl/-/binding-linux-riscv64-musl-11.20.0.tgz",
-            "integrity": "sha512-xHEvkbgz6UC+A3JOyDQy76LkUaxsNSfIr3/GV8slwZsnuooJiIB34gzJfsyvR4JdCYNUUPsRJc/w/oWkODu+hg==",
+            "version": "11.21.3",
+            "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-linux-riscv64-musl/-/binding-linux-riscv64-musl-11.21.3.tgz",
+            "integrity": "sha512-4UfsQvacV388y1zpXL7C1x1FNYaV52JtuNRiuzrfQA2z1z6ElVrsidkGsrvQ5EgeSq1Pj7kaKqrgGkvFuxJ/tw==",
             "cpu": [
                 "riscv64"
             ],
@@ -5945,9 +5945,9 @@
             ]
         },
         "node_modules/@oxc-resolver/binding-linux-s390x-gnu": {
-            "version": "11.20.0",
-            "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-11.20.0.tgz",
-            "integrity": "sha512-aWPDUUmSeyHvlW+SoEUd+JIJsQhVhu6a5tBpDRMu058naPAchTgAVGCFy35zjbnFlt0i8hLWziff6HX0D3LU4g==",
+            "version": "11.21.3",
+            "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-11.21.3.tgz",
+            "integrity": "sha512-b5uH+HKH0MP5mNBYaK75SKsJbw52URqrx2LavYdq6wb0l3ExAG5niYRP9DWUNHdKilpaBVM2bXk9HNWrH3ew7Q==",
             "cpu": [
                 "s390x"
             ],
@@ -5959,9 +5959,9 @@
             ]
         },
         "node_modules/@oxc-resolver/binding-linux-x64-gnu": {
-            "version": "11.20.0",
-            "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-linux-x64-gnu/-/binding-linux-x64-gnu-11.20.0.tgz",
-            "integrity": "sha512-x2YeSimvhJjKLVD8KSu8f/rqU1potcdEMkApIPJqjZWN7c2Fpt4g2X32WDg1p+XDAmyT7nuQGe0vnhvXeLbH+g==",
+            "version": "11.21.3",
+            "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-linux-x64-gnu/-/binding-linux-x64-gnu-11.21.3.tgz",
+            "integrity": "sha512-PjYlmilBpNRh2ntXNYAK3Am5w/nPfEpnU/96iNx7CI8EzAn12J4JRiec63wHJTH31nLoCNxBg/829pN+3CfG3Q==",
             "cpu": [
                 "x64"
             ],
@@ -5973,9 +5973,9 @@
             ]
         },
         "node_modules/@oxc-resolver/binding-linux-x64-musl": {
-            "version": "11.20.0",
-            "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-linux-x64-musl/-/binding-linux-x64-musl-11.20.0.tgz",
-            "integrity": "sha512-kcRLEIxpZefeYfLChjpgFf3ilBzRDZ+yobMrpRsQlSrxuFGtm3U6PMU7AaEpMqo3NfDGVyJJseAjnRLzMFHjwQ==",
+            "version": "11.21.3",
+            "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-linux-x64-musl/-/binding-linux-x64-musl-11.21.3.tgz",
+            "integrity": "sha512-QTBAb7JuHlZ7JUEyM8UiQi2f7m/L4swBhP2TNpYIDc9Wp/wRw1G/8sl6i13aIzQAXH7LKIm294LeOHd0lQR8zA==",
             "cpu": [
                 "x64"
             ],
@@ -5987,9 +5987,9 @@
             ]
         },
         "node_modules/@oxc-resolver/binding-openharmony-arm64": {
-            "version": "11.20.0",
-            "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-openharmony-arm64/-/binding-openharmony-arm64-11.20.0.tgz",
-            "integrity": "sha512-HHcfnApSZGtKhTiHqe8OZruOZe5XuFQH5/E0Yhj3u8fnFvzkM4/k6WjacUf4SvA0SPEAbfbgYmVPuo0VX/fIBQ==",
+            "version": "11.21.3",
+            "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-openharmony-arm64/-/binding-openharmony-arm64-11.21.3.tgz",
+            "integrity": "sha512-4j1DFwjwv36ec9kds0jU/ucQ5Ha4ERO/H95BxR5JFf0kqUUAJ1kwII7XhTc1vZrkdJkvLGC9Q2MbpObpum8RBg==",
             "cpu": [
                 "arm64"
             ],
@@ -6001,9 +6001,9 @@
             ]
         },
         "node_modules/@oxc-resolver/binding-wasm32-wasi": {
-            "version": "11.20.0",
-            "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-wasm32-wasi/-/binding-wasm32-wasi-11.20.0.tgz",
-            "integrity": "sha512-Tn0y1XOFYHNfK1wp1Z5QK8Rcld/bsOwRISQXfqAZ5IBpv8Gz1IvV39fUWNprqNdRizgcvFhOzWwFun2zkJsyBg==",
+            "version": "11.21.3",
+            "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-wasm32-wasi/-/binding-wasm32-wasi-11.21.3.tgz",
+            "integrity": "sha512-i8oluoel5kru/j1WNrjmQSiA3GQ7wvIYVR1IwIoZtKogAhya2iub+ZKIeSIkcJOrnzQ18Tzl/F+kL3fYOxZLvA==",
             "cpu": [
                 "wasm32"
             ],
@@ -6011,18 +6011,41 @@
             "license": "MIT",
             "optional": true,
             "dependencies": {
-                "@emnapi/core": "1.10.0",
-                "@emnapi/runtime": "1.10.0",
-                "@napi-rs/wasm-runtime": "^1.1.4"
+                "@emnapi/core": "1.11.0",
+                "@emnapi/runtime": "1.11.0",
+                "@napi-rs/wasm-runtime": "^1.1.5"
             },
             "engines": {
                 "node": ">=14.0.0"
             }
         },
+        "node_modules/@oxc-resolver/binding-wasm32-wasi/node_modules/@emnapi/core": {
+            "version": "1.11.0",
+            "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.11.0.tgz",
+            "integrity": "sha512-l9Oo58x0HOP5znGzVhYW9U3e5wVuA4LAZU2AGezTmkhO1CgQRFDhDg4nneHsu/t3WniXg9QrG2nIXL/ZS8ln8Q==",
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "dependencies": {
+                "@emnapi/wasi-threads": "1.2.2",
+                "tslib": "^2.4.0"
+            }
+        },
+        "node_modules/@oxc-resolver/binding-wasm32-wasi/node_modules/@emnapi/runtime": {
+            "version": "1.11.0",
+            "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.0.tgz",
+            "integrity": "sha512-55coeOFKHv1ywEcUXJtWU5f+Jr/W5tZDvZig8DLKSwUN1JpROQ4rk/SNOQiFWmaR/VKF4zuFyW1B8JduOSv6Pg==",
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "dependencies": {
+                "tslib": "^2.4.0"
+            }
+        },
         "node_modules/@oxc-resolver/binding-win32-arm64-msvc": {
-            "version": "11.20.0",
-            "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-11.20.0.tgz",
-            "integrity": "sha512-qPi25YNPe4YenS8MgsQU2+bIFHxxpLx1LVna2444cEHqNPhNjvWf9zqj4aWE43H9LpAsTmkkAlA3eL5ElBU3mA==",
+            "version": "11.21.3",
+            "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-11.21.3.tgz",
+            "integrity": "sha512-M/8dw8dD6aOs+NlPJax401CZB9I7Aut84isQLgALGGwke4Afvw+/7yYhZb94yXf6t2sPLhQLmSmtSV+2FhsOWg==",
             "cpu": [
                 "arm64"
             ],
@@ -6034,9 +6057,9 @@
             ]
         },
         "node_modules/@oxc-resolver/binding-win32-x64-msvc": {
-            "version": "11.20.0",
-            "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-win32-x64-msvc/-/binding-win32-x64-msvc-11.20.0.tgz",
-            "integrity": "sha512-Wb14jWEW8huH6It9F6sXd9vrYmIS7pMrgkU6sxpLxkP+9z+wRgs71hUEhRpcn8FOXAFa27FVWfY2tRpbfTzfLw==",
+            "version": "11.21.3",
+            "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-win32-x64-msvc/-/binding-win32-x64-msvc-11.21.3.tgz",
+            "integrity": "sha512-H7BCt/VnS9hnmMp42eGhZ99izSCRvlnWwy/N71K1/J8QoExwY4262Z8QiEkMDtduRJrztayDxETTckmUuAVL9Q==",
             "cpu": [
                 "x64"
             ],
@@ -6609,9 +6632,9 @@
             }
         },
         "node_modules/@tybys/wasm-util": {
-            "version": "0.10.2",
-            "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.2.tgz",
-            "integrity": "sha512-RoBvJ2X0wuKlWFIjrwffGw1IqZHKQqzIchKaadZZfnNpsAYp2mM0h36JtPCjNDAHGgYez/15uMBpfGwchhiMgg==",
+            "version": "0.10.3",
+            "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.3.tgz",
+            "integrity": "sha512-F3fo1MYrRJYL3zER0OUOmkutjr1Vp23m7OsSgp7nq4SP6OqX6C/56XFIPAl5bt3zaBRjmW7SGz3u/6LwFpYcOg==",
             "dev": true,
             "license": "MIT",
             "optional": true,
@@ -15101,9 +15124,9 @@
             }
         },
         "node_modules/knip": {
-            "version": "6.17.1",
-            "resolved": "https://registry.npmjs.org/knip/-/knip-6.17.1.tgz",
-            "integrity": "sha512-HcQsZSQ4Ymhuay4BVzJtM5pFZNDSomYYqcNCZOSITPQh9g18a09DqziWAxSt2G+BH9wGlG+0ZjWpEnaFlnKseQ==",
+            "version": "6.27.0",
+            "resolved": "https://registry.npmjs.org/knip/-/knip-6.27.0.tgz",
+            "integrity": "sha512-CngYEYrD0n20N06FXA8n3u/0Wnnugoa+B9k14OP+iKIgkCHuzvIdsP3nfwjhByoc1WfogpxfiriMboAXFETDUw==",
             "dev": true,
             "funding": [
                 {
@@ -15121,8 +15144,8 @@
                 "formatly": "^0.3.0",
                 "get-tsconfig": "4.14.0",
                 "jiti": "^2.7.0",
-                "oxc-parser": "^0.135.0",
-                "oxc-resolver": "^11.20.0",
+                "oxc-parser": "^0.137.0",
+                "oxc-resolver": "11.21.3",
                 "picomatch": "^4.0.4",
                 "smol-toml": "^1.6.1",
                 "strip-json-comments": "5.0.3",
@@ -18801,13 +18824,13 @@
             }
         },
         "node_modules/oxc-parser": {
-            "version": "0.135.0",
-            "resolved": "https://registry.npmjs.org/oxc-parser/-/oxc-parser-0.135.0.tgz",
-            "integrity": "sha512-/DaPStu0s2zzNSRRniKyTPM6Z/o+DapOp2JYNKDL8AsgaBGPK2IdZyB87SQjVH+xeQPz+Qr9mrjglfkYgtbVRA==",
+            "version": "0.137.0",
+            "resolved": "https://registry.npmjs.org/oxc-parser/-/oxc-parser-0.137.0.tgz",
+            "integrity": "sha512-yFImD+WLElJpLKy8llG1qe4DCmMsL18peRp8XP1JKfig/gISbJkglnpDtX2aTmAn10kZF7164HbN2H8QPsXxGg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@oxc-project/types": "^0.135.0"
+                "@oxc-project/types": "^0.137.0"
             },
             "engines": {
                 "node": "^20.19.0 || >=22.12.0"
@@ -18816,57 +18839,57 @@
                 "url": "https://github.com/sponsors/Boshen"
             },
             "optionalDependencies": {
-                "@oxc-parser/binding-android-arm-eabi": "0.135.0",
-                "@oxc-parser/binding-android-arm64": "0.135.0",
-                "@oxc-parser/binding-darwin-arm64": "0.135.0",
-                "@oxc-parser/binding-darwin-x64": "0.135.0",
-                "@oxc-parser/binding-freebsd-x64": "0.135.0",
-                "@oxc-parser/binding-linux-arm-gnueabihf": "0.135.0",
-                "@oxc-parser/binding-linux-arm-musleabihf": "0.135.0",
-                "@oxc-parser/binding-linux-arm64-gnu": "0.135.0",
-                "@oxc-parser/binding-linux-arm64-musl": "0.135.0",
-                "@oxc-parser/binding-linux-ppc64-gnu": "0.135.0",
-                "@oxc-parser/binding-linux-riscv64-gnu": "0.135.0",
-                "@oxc-parser/binding-linux-riscv64-musl": "0.135.0",
-                "@oxc-parser/binding-linux-s390x-gnu": "0.135.0",
-                "@oxc-parser/binding-linux-x64-gnu": "0.135.0",
-                "@oxc-parser/binding-linux-x64-musl": "0.135.0",
-                "@oxc-parser/binding-openharmony-arm64": "0.135.0",
-                "@oxc-parser/binding-wasm32-wasi": "0.135.0",
-                "@oxc-parser/binding-win32-arm64-msvc": "0.135.0",
-                "@oxc-parser/binding-win32-ia32-msvc": "0.135.0",
-                "@oxc-parser/binding-win32-x64-msvc": "0.135.0"
+                "@oxc-parser/binding-android-arm-eabi": "0.137.0",
+                "@oxc-parser/binding-android-arm64": "0.137.0",
+                "@oxc-parser/binding-darwin-arm64": "0.137.0",
+                "@oxc-parser/binding-darwin-x64": "0.137.0",
+                "@oxc-parser/binding-freebsd-x64": "0.137.0",
+                "@oxc-parser/binding-linux-arm-gnueabihf": "0.137.0",
+                "@oxc-parser/binding-linux-arm-musleabihf": "0.137.0",
+                "@oxc-parser/binding-linux-arm64-gnu": "0.137.0",
+                "@oxc-parser/binding-linux-arm64-musl": "0.137.0",
+                "@oxc-parser/binding-linux-ppc64-gnu": "0.137.0",
+                "@oxc-parser/binding-linux-riscv64-gnu": "0.137.0",
+                "@oxc-parser/binding-linux-riscv64-musl": "0.137.0",
+                "@oxc-parser/binding-linux-s390x-gnu": "0.137.0",
+                "@oxc-parser/binding-linux-x64-gnu": "0.137.0",
+                "@oxc-parser/binding-linux-x64-musl": "0.137.0",
+                "@oxc-parser/binding-openharmony-arm64": "0.137.0",
+                "@oxc-parser/binding-wasm32-wasi": "0.137.0",
+                "@oxc-parser/binding-win32-arm64-msvc": "0.137.0",
+                "@oxc-parser/binding-win32-ia32-msvc": "0.137.0",
+                "@oxc-parser/binding-win32-x64-msvc": "0.137.0"
             }
         },
         "node_modules/oxc-resolver": {
-            "version": "11.20.0",
-            "resolved": "https://registry.npmjs.org/oxc-resolver/-/oxc-resolver-11.20.0.tgz",
-            "integrity": "sha512-CblytBiV/a/ZXY34dsVU2NxhIOxMXst8CvDCtyBelVITgd7PLrKzbEbA6oKLdPjvDKDzCiW48qzmzZ+mYaqn+g==",
+            "version": "11.21.3",
+            "resolved": "https://registry.npmjs.org/oxc-resolver/-/oxc-resolver-11.21.3.tgz",
+            "integrity": "sha512-2Mx3fKQz7+xgrBONjsxOgCGtMHOn38/HxMzW1I5efwXB5a4lRN0Vp40gYUJFBWJslcrvwoofTrqoTnLbwTd3pA==",
             "dev": true,
             "license": "MIT",
             "funding": {
                 "url": "https://github.com/sponsors/Boshen"
             },
             "optionalDependencies": {
-                "@oxc-resolver/binding-android-arm-eabi": "11.20.0",
-                "@oxc-resolver/binding-android-arm64": "11.20.0",
-                "@oxc-resolver/binding-darwin-arm64": "11.20.0",
-                "@oxc-resolver/binding-darwin-x64": "11.20.0",
-                "@oxc-resolver/binding-freebsd-x64": "11.20.0",
-                "@oxc-resolver/binding-linux-arm-gnueabihf": "11.20.0",
-                "@oxc-resolver/binding-linux-arm-musleabihf": "11.20.0",
-                "@oxc-resolver/binding-linux-arm64-gnu": "11.20.0",
-                "@oxc-resolver/binding-linux-arm64-musl": "11.20.0",
-                "@oxc-resolver/binding-linux-ppc64-gnu": "11.20.0",
-                "@oxc-resolver/binding-linux-riscv64-gnu": "11.20.0",
-                "@oxc-resolver/binding-linux-riscv64-musl": "11.20.0",
-                "@oxc-resolver/binding-linux-s390x-gnu": "11.20.0",
-                "@oxc-resolver/binding-linux-x64-gnu": "11.20.0",
-                "@oxc-resolver/binding-linux-x64-musl": "11.20.0",
-                "@oxc-resolver/binding-openharmony-arm64": "11.20.0",
-                "@oxc-resolver/binding-wasm32-wasi": "11.20.0",
-                "@oxc-resolver/binding-win32-arm64-msvc": "11.20.0",
-                "@oxc-resolver/binding-win32-x64-msvc": "11.20.0"
+                "@oxc-resolver/binding-android-arm-eabi": "11.21.3",
+                "@oxc-resolver/binding-android-arm64": "11.21.3",
+                "@oxc-resolver/binding-darwin-arm64": "11.21.3",
+                "@oxc-resolver/binding-darwin-x64": "11.21.3",
+                "@oxc-resolver/binding-freebsd-x64": "11.21.3",
+                "@oxc-resolver/binding-linux-arm-gnueabihf": "11.21.3",
+                "@oxc-resolver/binding-linux-arm-musleabihf": "11.21.3",
+                "@oxc-resolver/binding-linux-arm64-gnu": "11.21.3",
+                "@oxc-resolver/binding-linux-arm64-musl": "11.21.3",
+                "@oxc-resolver/binding-linux-ppc64-gnu": "11.21.3",
+                "@oxc-resolver/binding-linux-riscv64-gnu": "11.21.3",
+                "@oxc-resolver/binding-linux-riscv64-musl": "11.21.3",
+                "@oxc-resolver/binding-linux-s390x-gnu": "11.21.3",
+                "@oxc-resolver/binding-linux-x64-gnu": "11.21.3",
+                "@oxc-resolver/binding-linux-x64-musl": "11.21.3",
+                "@oxc-resolver/binding-openharmony-arm64": "11.21.3",
+                "@oxc-resolver/binding-wasm32-wasi": "11.21.3",
+                "@oxc-resolver/binding-win32-arm64-msvc": "11.21.3",
+                "@oxc-resolver/binding-win32-x64-msvc": "11.21.3"
             }
         },
         "node_modules/p-cancelable": {

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
         "eslint": "^9.39.3",
         "eslint-plugin-markdownlint": "^0.10.1",
         "eslint-plugin-react": "^7.37.5",
-        "knip": "^6.17.1",
+        "knip": "^6.27.0",
         "lucide-react": "^1.21.0",
         "postcss": "^8.5.15",
         "prettier": "^3.9.6",


### PR DESCRIPTION
The knip 6.27.0 Dependabot bump (PR #797) now passes all CI checks after the baseUrl tsconfig fix in PR #801 was merged into main.

Changes:
- Bump knip from 6.17.1 to 6.27.0 (package.json + lockfile)