### PR TITLE
fix: knip 6.29.0 Dependabot bump passes CI

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -25,7 +25,7 @@
                 "eslint": "^9.39.3",
                 "eslint-plugin-markdownlint": "^0.10.1",
                 "eslint-plugin-react": "^7.37.5",
-                "knip": "^6.27.0",
+                "knip": "^6.29.0",
                 "lucide-react": "^1.26.0",
                 "postcss": "^8.5.23",
                 "prettier": "^3.9.6",
@@ -4493,9 +4493,9 @@
             }
         },
         "node_modules/@emnapi/core": {
-            "version": "1.11.1",
-            "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.11.1.tgz",
-            "integrity": "sha512-RSvbQmHzdKzNsLYa/wHrbc3KN4sYLKAdPZxqiM2HATqv/SBk2/ENSHpvXGaLOMcsAyz0poEGqkmmKYG3OWiJEQ==",
+            "version": "1.11.2",
+            "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.11.2.tgz",
+            "integrity": "sha512-TC8MkTuZUtcTSiFeuC0ksCh9QIJ5+F21MvZ4Wn4ORfYaFJ/0dsiudv5tVkejgwZlwQ39jL9WWDe2lz8x0WglOA==",
             "dev": true,
             "license": "MIT",
             "optional": true,
@@ -4505,9 +4505,9 @@
             }
         },
         "node_modules/@emnapi/runtime": {
-            "version": "1.11.1",
-            "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.1.tgz",
-            "integrity": "sha512-vgj7R3y3Wgx24IQaGPA/R6YFXLHVMOZ0uVEyIQPaWs+rd1AzfEMXlAC22FYwO1XkKR6NPsq7mUandH8oIRdZFw==",
+            "version": "1.11.2",
+            "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.2.tgz",
+            "integrity": "sha512-kyOl3X0DuTiT1h2ft8r2fYO8JYtU9a9Xis/zBSiGArNaagCOWx90N1k2wxp18czFDH+OgcWGb5ZP/XMt3dcyPA==",
             "dev": true,
             "license": "MIT",
             "optional": true,
@@ -5425,9 +5425,9 @@
             }
         },
         "node_modules/@oxc-parser/binding-android-arm-eabi": {
-            "version": "0.137.0",
-            "resolved": "https://registry.npmjs.org/@oxc-parser/binding-android-arm-eabi/-/binding-android-arm-eabi-0.137.0.tgz",
-            "integrity": "sha512-KDs+0VPdEmasOkpuJHW9V5WCF+cvYdMQv2Jd+aJXt+cxIx12NToRQRbXaRwUEDsZw+/jMk81Ve8ZFbjUkJTOwA==",
+            "version": "0.140.0",
+            "resolved": "https://registry.npmjs.org/@oxc-parser/binding-android-arm-eabi/-/binding-android-arm-eabi-0.140.0.tgz",
+            "integrity": "sha512-ZfjDZ422mo7eo3b3VltqNsV9kmv1qt/sPEAMSl64iOSwhVfd0eIZ9LB79Mbs1xYXJnk7WSROwzBCKDIiVxPTvQ==",
             "cpu": [
                 "arm"
             ],
@@ -5442,9 +5442,9 @@
             }
         },
         "node_modules/@oxc-parser/binding-android-arm64": {
-            "version": "0.137.0",
-            "resolved": "https://registry.npmjs.org/@oxc-parser/binding-android-arm64/-/binding-android-arm64-0.137.0.tgz",
-            "integrity": "sha512-WhALNzfy3x/RfC6bsqX+csavuUY0yHHE7XfgPE5M542uhoBZUUoGTPG+nkMbGoG4+gcfss5s7urMyn5QBHu0sw==",
+            "version": "0.140.0",
+            "resolved": "https://registry.npmjs.org/@oxc-parser/binding-android-arm64/-/binding-android-arm64-0.140.0.tgz",
+            "integrity": "sha512-Ia8jSvikUX6Sf+Ht+KOCUF/k1HpR0VlmqIYymubmWDebOEGtsyliHDR6JxsZ4IX3/c/GbrB1uh09aVGQv/LQmQ==",
             "cpu": [
                 "arm64"
             ],
@@ -5459,9 +5459,9 @@
             }
         },
         "node_modules/@oxc-parser/binding-darwin-arm64": {
-            "version": "0.137.0",
-            "resolved": "https://registry.npmjs.org/@oxc-parser/binding-darwin-arm64/-/binding-darwin-arm64-0.137.0.tgz",
-            "integrity": "sha512-bFPr5hgmNMOMoyPTGtdsK4Ug21RovIPojRMgDDhSp1LtCnc/DkLwGONKjgRjszg677RlGnkYSviQ8hHaUPOVYA==",
+            "version": "0.140.0",
+            "resolved": "https://registry.npmjs.org/@oxc-parser/binding-darwin-arm64/-/binding-darwin-arm64-0.140.0.tgz",
+            "integrity": "sha512-G6VK0nK61pH0d0mBjUqSZbVxGqqO5uzeginLDQj+gOO6ObfJjXRwgkD/ol0w1INcnFeAb6YGGO7qc3ueGHaycQ==",
             "cpu": [
                 "arm64"
             ],
@@ -5476,9 +5476,9 @@
             }
         },
         "node_modules/@oxc-parser/binding-darwin-x64": {
-            "version": "0.137.0",
-            "resolved": "https://registry.npmjs.org/@oxc-parser/binding-darwin-x64/-/binding-darwin-x64-0.137.0.tgz",
-            "integrity": "sha512-CL5dMm1asqXIDZHg14FLxj3Mc36w8PI7xCWh1uA4is6z8g2XrIILoTcQYOxDbwzuk34RDPX5IAGUxZr6LA9KAg==",
+            "version": "0.140.0",
+            "resolved": "https://registry.npmjs.org/@oxc-parser/binding-darwin-x64/-/binding-darwin-x64-0.140.0.tgz",
+            "integrity": "sha512-HazBOuZzd2pO1C2uMmp8Gv7mhzMHqKSKDS1OZfcLEvpIcgA+48J92HEtNanVHDIzRD9PRPCV6aS6fkZIWOVl8Q==",
             "cpu": [
                 "x64"
             ],
@@ -5493,9 +5493,9 @@
             }
         },
         "node_modules/@oxc-parser/binding-freebsd-x64": {
-            "version": "0.137.0",
-            "resolved": "https://registry.npmjs.org/@oxc-parser/binding-freebsd-x64/-/binding-freebsd-x64-0.137.0.tgz",
-            "integrity": "sha512-79h8rYGnSlKPGWo7mHr2ixO6ea7aW8B0CT965SZ8SLbNnCOH5aOYBTeVXUY6eMvEaiLyWr8Skuiugr5pDYgLGw==",
+            "version": "0.140.0",
+            "resolved": "https://registry.npmjs.org/@oxc-parser/binding-freebsd-x64/-/binding-freebsd-x64-0.140.0.tgz",
+            "integrity": "sha512-9hSUU+HmTUyOe4JzMHxNGgLWNY7rrO+6ShicZwImNJacEAACDMIkuEQQkvXSL+WJN50jaNtLYJv8s4OcBdpyUQ==",
             "cpu": [
                 "x64"
             ],
@@ -5510,9 +5510,9 @@
             }
         },
         "node_modules/@oxc-parser/binding-linux-arm-gnueabihf": {
-            "version": "0.137.0",
-            "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-0.137.0.tgz",
-            "integrity": "sha512-ASgmlSimhGyr0lksgVIo6hibz1obnDq4qJbiMX/AzltfgPnanRrzG1Q+23g8ljOHOjv6dsznkUuCYL3gg0sY1Q==",
+            "version": "0.140.0",
+            "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-0.140.0.tgz",
+            "integrity": "sha512-RAEuQsYtS0KcDFqN0ABTjyyNlokS91JeuDuoW9tEbG0JTbRNXnpQUdbYc/16JoA6Z/2ALbNrE3KmxtqDiuIjCQ==",
             "cpu": [
                 "arm"
             ],
@@ -5527,9 +5527,9 @@
             }
         },
         "node_modules/@oxc-parser/binding-linux-arm-musleabihf": {
-            "version": "0.137.0",
-            "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-arm-musleabihf/-/binding-linux-arm-musleabihf-0.137.0.tgz",
-            "integrity": "sha512-AU2J9aa22Sx32wRGnDjybOU9TQXXQUud5sdUi+ZB0XxwM8aToWLweV+yA0wlQm0yIUVqljquqoHCYEq9II8gJQ==",
+            "version": "0.140.0",
+            "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-arm-musleabihf/-/binding-linux-arm-musleabihf-0.140.0.tgz",
+            "integrity": "sha512-c4CkHvPvqfojouredJ0w3e6+jiBq0SbFyhH61kr/zPb/7XsaYTNKQ54vmlSsopfdQbNDX40ZeK9Abs2Qet6wcw==",
             "cpu": [
                 "arm"
             ],
@@ -5544,9 +5544,9 @@
             }
         },
         "node_modules/@oxc-parser/binding-linux-arm64-gnu": {
-            "version": "0.137.0",
-            "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-0.137.0.tgz",
-            "integrity": "sha512-GdEtiG89yMr7XkUGxifgodXEEm2f+xW2f9CpDjlgAnBOwhTmrpQMvhOGobLVKUyzf/qHBXW16smk5zbF3nZU6w==",
+            "version": "0.140.0",
+            "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-0.140.0.tgz",
+            "integrity": "sha512-yrjmLj8ixPB25yqvPGr28meGjb+keed7m1GqqY/0uqkhZIoT4t9zmfwUgFEtC33C7dtE+UQ7TU0IaVxf97SWJg==",
             "cpu": [
                 "arm64"
             ],
@@ -5561,9 +5561,9 @@
             }
         },
         "node_modules/@oxc-parser/binding-linux-arm64-musl": {
-            "version": "0.137.0",
-            "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-arm64-musl/-/binding-linux-arm64-musl-0.137.0.tgz",
-            "integrity": "sha512-EGJ+Bs8iXx8KBH8DQ5BLoEm5lnHaYjlh4/8j8vFhrr/6z4tqONy5BZDzLpKmmNWlN6Hlc5r8YOuBVHqZ9vRFEQ==",
+            "version": "0.140.0",
+            "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-arm64-musl/-/binding-linux-arm64-musl-0.140.0.tgz",
+            "integrity": "sha512-ggGMQTN8Agwxp2WiLMpdY671dt0qTDJWiWlJeig3HnUwTnerRl0J2JdGVghWBeDcss2D9S2V2Js6dZHEiVabVA==",
             "cpu": [
                 "arm64"
             ],
@@ -5578,9 +5578,9 @@
             }
         },
         "node_modules/@oxc-parser/binding-linux-ppc64-gnu": {
-            "version": "0.137.0",
-            "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-0.137.0.tgz",
-            "integrity": "sha512-vzFUQENy/fnbSe5DZWovq6tIBc1uhuMztanSW6rz1e9WdQE4gHwYuD7ZII6JnrJifd1R3RSoqiZbgRFlVL2tYQ==",
+            "version": "0.140.0",
+            "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-0.140.0.tgz",
+            "integrity": "sha512-IgTs8xYAFgAUGNmR65tIqjlJ8vKgrfXzC515e9goSdfMyKQV4aJpd2pUUudU4u51G64H0/DSEJEXKOraxm9ZCA==",
             "cpu": [
                 "ppc64"
             ],
@@ -5595,9 +5595,9 @@
             }
         },
         "node_modules/@oxc-parser/binding-linux-riscv64-gnu": {
-            "version": "0.137.0",
-            "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-riscv64-gnu/-/binding-linux-riscv64-gnu-0.137.0.tgz",
-            "integrity": "sha512-SfVI14HBQs9gtLcUD5hTt5hsNbdrqSUNg9S8muN+LhVQ5nf1WwH3hAoK6B9NKgdYgWAQSXFXGiiBedQ4r/BKuw==",
+            "version": "0.140.0",
+            "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-riscv64-gnu/-/binding-linux-riscv64-gnu-0.140.0.tgz",
+            "integrity": "sha512-A1x+PMWZmSGaFVOx2YeNTFau8uD+QO14/vLP4GrcuvUPs3+nBkUOjy9Lus86ftHsDojjYMbvBelmKc3F7Rv08g==",
             "cpu": [
                 "riscv64"
             ],
@@ -5612,9 +5612,9 @@
             }
         },
         "node_modules/@oxc-parser/binding-linux-riscv64-musl": {
-            "version": "0.137.0",
-            "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-riscv64-musl/-/binding-linux-riscv64-musl-0.137.0.tgz",
-            "integrity": "sha512-e7Ppy4FCIFNQxT/ikSeIWFoQ0l+N9vgtRBtLcyZXeolTzApyVoPqEXsYPrcdM/9i0Bwk8knvYd37vaEMxHyi6g==",
+            "version": "0.140.0",
+            "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-riscv64-musl/-/binding-linux-riscv64-musl-0.140.0.tgz",
+            "integrity": "sha512-zBqpfRo2myWPrPo5xUjeZqlnPXPXsX8BcWtWff66/eGRQdbPjhzPgXa/F+AtxT2afUViPxbuDlwscMKzQ5tg+g==",
             "cpu": [
                 "riscv64"
             ],
@@ -5629,9 +5629,9 @@
             }
         },
         "node_modules/@oxc-parser/binding-linux-s390x-gnu": {
-            "version": "0.137.0",
-            "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-0.137.0.tgz",
-            "integrity": "sha512-Bho5qFwdhqsIFR7gipYEUlqvi3SRrY8sugxXig380MIaakBB1PyU9+7dBiBVScfImTNWhijUxdBwqrprGdq5WA==",
+            "version": "0.140.0",
+            "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-0.140.0.tgz",
+            "integrity": "sha512-2M1DPm/8w9I//YzFlFC9qXw+r2tJFh5CYwRlYTq2vUJQS7qoQftEDeCZ8EnN7KHtvSiXvYj8mZI5pR7DpXmcEw==",
             "cpu": [
                 "s390x"
             ],
@@ -5646,9 +5646,9 @@
             }
         },
         "node_modules/@oxc-parser/binding-linux-x64-gnu": {
-            "version": "0.137.0",
-            "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-x64-gnu/-/binding-linux-x64-gnu-0.137.0.tgz",
-            "integrity": "sha512-36mGWtg7PyFzjJwGDkH6/F4o2nIDEoKXLPr/X/lwqklkomQwJJt1I5GJVmGhovUEmgPK5WAeAZMqlFCehwiy9Q==",
+            "version": "0.140.0",
+            "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-x64-gnu/-/binding-linux-x64-gnu-0.140.0.tgz",
+            "integrity": "sha512-8aRDbZ/U/jO8N7go1MO72jtbpb4uswV8d7vOkMvt/BPgZiyEYvl1VIWK4ESxZZhnJ4tqwVldgX7dNiP/eB1Jdg==",
             "cpu": [
                 "x64"
             ],
@@ -5663,9 +5663,9 @@
             }
         },
         "node_modules/@oxc-parser/binding-linux-x64-musl": {
-            "version": "0.137.0",
-            "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-x64-musl/-/binding-linux-x64-musl-0.137.0.tgz",
-            "integrity": "sha512-/Jqx6+N7A44n2BdvUr7pXhVr2vFjs6WGH3unZRczwrfiH0H1zY0QwKQMG/dtRiTlKGDKGukznPT8lx84/oEsZg==",
+            "version": "0.140.0",
+            "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-x64-musl/-/binding-linux-x64-musl-0.140.0.tgz",
+            "integrity": "sha512-xRqpeI8U2sQQS1W5BMWRyMTxtagkuLG2dEWruet5lFsWHTvBth11/TpSaJatHdqVVwHN0q3uuoS9zRsGinq8hg==",
             "cpu": [
                 "x64"
             ],
@@ -5680,9 +5680,9 @@
             }
         },
         "node_modules/@oxc-parser/binding-openharmony-arm64": {
-            "version": "0.137.0",
-            "resolved": "https://registry.npmjs.org/@oxc-parser/binding-openharmony-arm64/-/binding-openharmony-arm64-0.137.0.tgz",
-            "integrity": "sha512-9Uj0qHNNl+OgT1UTGwF7ixIXU6T1u2SbMidmgPy/h1h/fl2gRS6YpAxxY1gwHofcWjoTwkoMFd8xs5Vuj6GOFA==",
+            "version": "0.140.0",
+            "resolved": "https://registry.npmjs.org/@oxc-parser/binding-openharmony-arm64/-/binding-openharmony-arm64-0.140.0.tgz",
+            "integrity": "sha512-GbGRe26MqAKciFRvXeHNQJ6VAHYs9R4miP89sEAncysM3n+f4lnyLWgsa9kklJNpfnxdq2yRoNYHFqwBckVimw==",
             "cpu": [
                 "arm64"
             ],
@@ -5697,9 +5697,9 @@
             }
         },
         "node_modules/@oxc-parser/binding-wasm32-wasi": {
-            "version": "0.137.0",
-            "resolved": "https://registry.npmjs.org/@oxc-parser/binding-wasm32-wasi/-/binding-wasm32-wasi-0.137.0.tgz",
-            "integrity": "sha512-gW2vfkytNGgMVADiuzdvOfw0mWG9za20F/1fCJsif5aBMAvWJTSbpIXbIe0XkOe0VENk+PadpQ7cZgUy2sUJcA==",
+            "version": "0.140.0",
+            "resolved": "https://registry.npmjs.org/@oxc-parser/binding-wasm32-wasi/-/binding-wasm32-wasi-0.140.0.tgz",
+            "integrity": "sha512-vFiC1hqys+hkX1GnQkIoiTQJNiUm43Z0lO35ETKXTw0YtpW7+cN58YRRXFAQQ+TgpkIi3lrhcxdlnqz+Oi3ptQ==",
             "cpu": [
                 "wasm32"
             ],
@@ -5707,18 +5707,18 @@
             "license": "MIT",
             "optional": true,
             "dependencies": {
-                "@emnapi/core": "1.11.1",
-                "@emnapi/runtime": "1.11.1",
-                "@napi-rs/wasm-runtime": "^1.1.5"
+                "@emnapi/core": "1.11.2",
+                "@emnapi/runtime": "1.11.2",
+                "@napi-rs/wasm-runtime": "^1.1.6"
             },
             "engines": {
                 "node": "^20.19.0 || >=22.12.0"
             }
         },
         "node_modules/@oxc-parser/binding-win32-arm64-msvc": {
-            "version": "0.137.0",
-            "resolved": "https://registry.npmjs.org/@oxc-parser/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-0.137.0.tgz",
-            "integrity": "sha512-x+pFANF0yL5uK/6T7lu6SlR5qid6sp//eZXKLq5iNsIE+EQg6EaS8/wsW7E91nXXjpnPhSoMOHXShSVhGRdn8w==",
+            "version": "0.140.0",
+            "resolved": "https://registry.npmjs.org/@oxc-parser/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-0.140.0.tgz",
+            "integrity": "sha512-fGSQldwEYKhM+H8uLt76Op8hh5+FYaR6lvvQ1Txw3Mhn86DyQXLcI0fi1EkFlTK7F+46OCk/j0AJMzZQm6g5Xg==",
             "cpu": [
                 "arm64"
             ],
@@ -5733,9 +5733,9 @@
             }
         },
         "node_modules/@oxc-parser/binding-win32-ia32-msvc": {
-            "version": "0.137.0",
-            "resolved": "https://registry.npmjs.org/@oxc-parser/binding-win32-ia32-msvc/-/binding-win32-ia32-msvc-0.137.0.tgz",
-            "integrity": "sha512-sQUqym80PFi6McRsIqfJrSu2JrSClEZIXXD+/FjAFoULEKzOPsldIdFBG96xdX8aVMzCNQ9792FPx3MfkEIrFA==",
+            "version": "0.140.0",
+            "resolved": "https://registry.npmjs.org/@oxc-parser/binding-win32-ia32-msvc/-/binding-win32-ia32-msvc-0.140.0.tgz",
+            "integrity": "sha512-sDS2Bai+g3ZWYwfZqmosiSuFDBcVnZ3Ta6pszzsiJoLMqsJEWKcxXXbGa7b7yXr++W2lQNPb3ZRJ8czseqL7RA==",
             "cpu": [
                 "ia32"
             ],
@@ -5750,9 +5750,9 @@
             }
         },
         "node_modules/@oxc-parser/binding-win32-x64-msvc": {
-            "version": "0.137.0",
-            "resolved": "https://registry.npmjs.org/@oxc-parser/binding-win32-x64-msvc/-/binding-win32-x64-msvc-0.137.0.tgz",
-            "integrity": "sha512-2AsevxlvNN4WKxpEn3RtqD5zbqMaXF+T7JXblsP4gVuY+vC9dXS4ED/PwfRCliFqoeisYS3Iro4DHzxr0TEvVA==",
+            "version": "0.140.0",
+            "resolved": "https://registry.npmjs.org/@oxc-parser/binding-win32-x64-msvc/-/binding-win32-x64-msvc-0.140.0.tgz",
+            "integrity": "sha512-kHbE1zWyb5OQgJA6/5P4WjiuB01sYdQwtZnSSyE58FQEXDAMnyeeq4vj7KgN75i5SlBzOs8A5MrtlD3gOlDKqQ==",
             "cpu": [
                 "x64"
             ],
@@ -5767,9 +5767,9 @@
             }
         },
         "node_modules/@oxc-project/types": {
-            "version": "0.137.0",
-            "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.137.0.tgz",
-            "integrity": "sha512-WT+Gb24i8hmvo85AIv2oEYouEXkRlKAlT9WaCa3TfLgNCN+GhrJOGZuIlMouAh38Qe4QOx26eUOVsq70qXrywA==",
+            "version": "0.140.0",
+            "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.140.0.tgz",
+            "integrity": "sha512-h5LUOzGArYemnW1NMz/DuuQhBi96J6JL2Bk8zE4kvqxB5Sg3jxmCiH4uyOWHDkiKSt5vWlG4FIwCR/DbstcNRQ==",
             "dev": true,
             "license": "MIT",
             "funding": {
@@ -5777,9 +5777,9 @@
             }
         },
         "node_modules/@oxc-resolver/binding-android-arm-eabi": {
-            "version": "11.21.3",
-            "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-android-arm-eabi/-/binding-android-arm-eabi-11.21.3.tgz",
-            "integrity": "sha512-eNU11A2WNizh04v3uyaJCootrHIaS0B9aHYXvAvVnPNk4xYSjMUjHnhQ6dewPN2MRYDskV85d1N0Aw0WNWhcyg==",
+            "version": "11.24.2",
+            "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-android-arm-eabi/-/binding-android-arm-eabi-11.24.2.tgz",
+            "integrity": "sha512-y09e0L0SRI2OA2tUIrjBgoV3eH5hvUKXNkJqXmNo5V2WxIjyC7I7aJfRLMEVpA8yi95f90gFDvO0VMgrDw+vwA==",
             "cpu": [
                 "arm"
             ],
@@ -5791,9 +5791,9 @@
             ]
         },
         "node_modules/@oxc-resolver/binding-android-arm64": {
-            "version": "11.21.3",
-            "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-android-arm64/-/binding-android-arm64-11.21.3.tgz",
-            "integrity": "sha512-8Q+ZjTLvn2dIcWsrmhdrEihm7q+ag/k+mkry7Z+t0QbbHaVxXQfvH9AewyVMh/WrpEKhQ3DDgx9fYbqeCpeOEw==",
+            "version": "11.24.2",
+            "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-android-arm64/-/binding-android-arm64-11.24.2.tgz",
+            "integrity": "sha512-cl4icWaZFnLdg8m6qtnh5rBMuGbxc/ptStFHLeCNwr+2cZjkjNwQu/jYRS0CHlnPecOJMpuS5M6/BH+0J/YkEg==",
             "cpu": [
                 "arm64"
             ],
@@ -5805,9 +5805,9 @@
             ]
         },
         "node_modules/@oxc-resolver/binding-darwin-arm64": {
-            "version": "11.21.3",
-            "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-darwin-arm64/-/binding-darwin-arm64-11.21.3.tgz",
-            "integrity": "sha512-wkh0qKZGHXVUDxFw3oA1TXnU2BDYY/r775oJflGeIr8uDPPoN2pk8gijQIzYRT6hoql/lg3+Tx/SaTn9e2/aGg==",
+            "version": "11.24.2",
+            "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-darwin-arm64/-/binding-darwin-arm64-11.24.2.tgz",
+            "integrity": "sha512-At29QEMF6HajbQvgY8K6OXnHD1x9rad74xBEfmCB6ZqCGsdq75aK7tOYcTbOanMy8qdIBrfL3SMr3p/lfSlb9w==",
             "cpu": [
                 "arm64"
             ],
@@ -5819,9 +5819,9 @@
             ]
         },
         "node_modules/@oxc-resolver/binding-darwin-x64": {
-            "version": "11.21.3",
-            "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-darwin-x64/-/binding-darwin-x64-11.21.3.tgz",
-            "integrity": "sha512-HbNc23FAQYbuyDV2vBWMez4u4mrsm5RAkniGZAWqr6lYZ3N4beeqIb776jzwRl8qL2zRhHVXpUj97X0QgogVzg==",
+            "version": "11.24.2",
+            "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-darwin-x64/-/binding-darwin-x64-11.24.2.tgz",
+            "integrity": "sha512-A5Kqr1EUj4oIL5CF4WRssq/o5P0Y11cwoFouMRmQ7YnC/A8V93nv1nb7aSU8HwcgmXropjLNkVTl4MN87cu28Q==",
             "cpu": [
                 "x64"
             ],
@@ -5833,9 +5833,9 @@
             ]
         },
         "node_modules/@oxc-resolver/binding-freebsd-x64": {
-            "version": "11.21.3",
-            "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-freebsd-x64/-/binding-freebsd-x64-11.21.3.tgz",
-            "integrity": "sha512-K6xNsTUPEUdfrn0+kbMq5nOUB5w1C5pavPQngt4TM2FpN91lP0PBe2srSpamb4d69O7h86oAi/qWX/kZNRSjkw==",
+            "version": "11.24.2",
+            "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-freebsd-x64/-/binding-freebsd-x64-11.24.2.tgz",
+            "integrity": "sha512-R5xkRBRRz7ceH/P5Jrc6G7FmdUdgpLYyESFAUDVTNQ9K0sGPxcp4ljiwEwEqsvNcQ4sYbMRrWcHHBCu7ksAJVw==",
             "cpu": [
                 "x64"
             ],
@@ -5847,9 +5847,9 @@
             ]
         },
         "node_modules/@oxc-resolver/binding-linux-arm-gnueabihf": {
-            "version": "11.21.3",
-            "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-11.21.3.tgz",
-            "integrity": "sha512-VcFmOpcpWX1zoEy8M58tR2M9YxM+Z9RuQhqAx5q0CTmrruaP7Gveejg75hzd/5sg5nk9G3aLALEa3hE2FsmmTQ==",
+            "version": "11.24.2",
+            "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-11.24.2.tgz",
+            "integrity": "sha512-k/RuYL4L/R58IBn3wT5ma3Wh4k62bp1eYCFRWCmMsasUOqL+H6sW0VGFadEzKWXFFlz+2uIMoeMk9ySSZJHgbg==",
             "cpu": [
                 "arm"
             ],
@@ -5861,9 +5861,9 @@
             ]
         },
         "node_modules/@oxc-resolver/binding-linux-arm-musleabihf": {
-            "version": "11.21.3",
-            "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-linux-arm-musleabihf/-/binding-linux-arm-musleabihf-11.21.3.tgz",
-            "integrity": "sha512-quVoxFLBy43hWaQbbDtQNRwAX5vX76mv7n64icAtQcJ3eNgVeblqmkupF/hAneNthdqSlnd1sTjb3aQSaDPaCQ==",
+            "version": "11.24.2",
+            "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-linux-arm-musleabihf/-/binding-linux-arm-musleabihf-11.24.2.tgz",
+            "integrity": "sha512-bnHAak3ujYfH5pKk4NieFNbvYvernfoQDgwLddbZ3OtMYrem87/qjlA+u+aKG0oZcqSLGCful/6/CEA+aeAgaA==",
             "cpu": [
                 "arm"
             ],
@@ -5875,9 +5875,9 @@
             ]
         },
         "node_modules/@oxc-resolver/binding-linux-arm64-gnu": {
-            "version": "11.21.3",
-            "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-11.21.3.tgz",
-            "integrity": "sha512-X0AqNZgcD07Q4V3RDK18/vYOj/HQT/FnmEFGYS2jTWqY7JO13ryE3TEs3eAIgUJhBnNkpEaiXqz3VK8M7qQhWQ==",
+            "version": "11.24.2",
+            "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-11.24.2.tgz",
+            "integrity": "sha512-vDT3KHgzYp47gmtNOqL2VNhCyl5Zv643eyxm//A68J8DeUGXrvD1pZFiaT4jSfe+RInfnn1R2yVHye4enx6RnA==",
             "cpu": [
                 "arm64"
             ],
@@ -5889,9 +5889,9 @@
             ]
         },
         "node_modules/@oxc-resolver/binding-linux-arm64-musl": {
-            "version": "11.21.3",
-            "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-linux-arm64-musl/-/binding-linux-arm64-musl-11.21.3.tgz",
-            "integrity": "sha512-YkaQnaKYdbuaXvRt5Qd0GpbihzVnyfR6z1SpYfIUC6RTu4NF7lDKPjVkYb+jRI2gedVO2rVpN35Y6akG6ud4Lw==",
+            "version": "11.24.2",
+            "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-linux-arm64-musl/-/binding-linux-arm64-musl-11.24.2.tgz",
+            "integrity": "sha512-+kMlQvbzfyEYtu5FcjE4p+ttBLpKW4d/AsAsuE69BxV6V4twZJeIQZFfD8gh/wqglY0MkPSezWXQH0jBV13MUw==",
             "cpu": [
                 "arm64"
             ],
@@ -5903,9 +5903,9 @@
             ]
         },
         "node_modules/@oxc-resolver/binding-linux-ppc64-gnu": {
-            "version": "11.21.3",
-            "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-11.21.3.tgz",
-            "integrity": "sha512-gB9HwhrPiFqUzDeEq+y/CgAijz1YdI6BnXz5GaH2Pa9cWdutchlkGFAiAuGb/PjVQpiK6NFKzFuztxrweoit7A==",
+            "version": "11.24.2",
+            "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-11.24.2.tgz",
+            "integrity": "sha512-shjfMhmZ3gq9fv/w7bi3PnZlgOPG+2QAOFf0BJF0EgBSIGZ6PMLN2zbGEblTUYB/NKVDRyYhE2ff3dJ1QqNPkA==",
             "cpu": [
                 "ppc64"
             ],
@@ -5917,9 +5917,9 @@
             ]
         },
         "node_modules/@oxc-resolver/binding-linux-riscv64-gnu": {
-            "version": "11.21.3",
-            "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-linux-riscv64-gnu/-/binding-linux-riscv64-gnu-11.21.3.tgz",
-            "integrity": "sha512-zjDWBlYk8QGv0H8dsPUWqkfjYIIjG2TvspGkzXL0eImbgxtZorA/klKeHyolevoT3Kvbi+1iMr9Lhrh7jf54Og==",
+            "version": "11.24.2",
+            "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-linux-riscv64-gnu/-/binding-linux-riscv64-gnu-11.24.2.tgz",
+            "integrity": "sha512-zGelwFR5oRo+b69k8Lrzun86DyUHzfKN6cnjbR9l7Z7NIRznOE/2ZvPa1IUKqAL2PzAXOdwkfVqNvO1H2RlpAw==",
             "cpu": [
                 "riscv64"
             ],
@@ -5931,9 +5931,9 @@
             ]
         },
         "node_modules/@oxc-resolver/binding-linux-riscv64-musl": {
-            "version": "11.21.3",
-            "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-linux-riscv64-musl/-/binding-linux-riscv64-musl-11.21.3.tgz",
-            "integrity": "sha512-4UfsQvacV388y1zpXL7C1x1FNYaV52JtuNRiuzrfQA2z1z6ElVrsidkGsrvQ5EgeSq1Pj7kaKqrgGkvFuxJ/tw==",
+            "version": "11.24.2",
+            "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-linux-riscv64-musl/-/binding-linux-riscv64-musl-11.24.2.tgz",
+            "integrity": "sha512-qxZ1SWCXJY0eyhAlP6Lmo9F2Nrtx7EkYj9oCgL8apDPCwXwCEDA2U697bbT81JIc2IrVjxO4KX6WU2N+oN9Z4w==",
             "cpu": [
                 "riscv64"
             ],
@@ -5945,9 +5945,9 @@
             ]
         },
         "node_modules/@oxc-resolver/binding-linux-s390x-gnu": {
-            "version": "11.21.3",
-            "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-11.21.3.tgz",
-            "integrity": "sha512-b5uH+HKH0MP5mNBYaK75SKsJbw52URqrx2LavYdq6wb0l3ExAG5niYRP9DWUNHdKilpaBVM2bXk9HNWrH3ew7Q==",
+            "version": "11.24.2",
+            "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-11.24.2.tgz",
+            "integrity": "sha512-sGCecF3cx2DFlH4t/z7ApnOnXqN48p5p5mlHDEnHTAukQa2P+qMVE4CwyWE9W+q/m3QJ7kKfGrIjax31f44oFQ==",
             "cpu": [
                 "s390x"
             ],
@@ -5959,9 +5959,9 @@
             ]
         },
         "node_modules/@oxc-resolver/binding-linux-x64-gnu": {
-            "version": "11.21.3",
-            "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-linux-x64-gnu/-/binding-linux-x64-gnu-11.21.3.tgz",
-            "integrity": "sha512-PjYlmilBpNRh2ntXNYAK3Am5w/nPfEpnU/96iNx7CI8EzAn12J4JRiec63wHJTH31nLoCNxBg/829pN+3CfG3Q==",
+            "version": "11.24.2",
+            "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-linux-x64-gnu/-/binding-linux-x64-gnu-11.24.2.tgz",
+            "integrity": "sha512-k/VlMMcSzMlahb3/fENM4rTlsJ0s3fFROA0KXPBmKggqmTSaE383sl8F3KCOXPLmVsYfW6hCitMhXCEtNeZxxg==",
             "cpu": [
                 "x64"
             ],
@@ -5973,9 +5973,9 @@
             ]
         },
         "node_modules/@oxc-resolver/binding-linux-x64-musl": {
-            "version": "11.21.3",
-            "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-linux-x64-musl/-/binding-linux-x64-musl-11.21.3.tgz",
-            "integrity": "sha512-QTBAb7JuHlZ7JUEyM8UiQi2f7m/L4swBhP2TNpYIDc9Wp/wRw1G/8sl6i13aIzQAXH7LKIm294LeOHd0lQR8zA==",
+            "version": "11.24.2",
+            "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-linux-x64-musl/-/binding-linux-x64-musl-11.24.2.tgz",
+            "integrity": "sha512-8hbnZyNi97b/8wapYaIF9+t9GmZKBW2vunaOc3h9HGJptH7b7XpvZqOTBSm/MpTjr7H497BlgOaSfLUdhmy2bw==",
             "cpu": [
                 "x64"
             ],
@@ -5987,9 +5987,9 @@
             ]
         },
         "node_modules/@oxc-resolver/binding-openharmony-arm64": {
-            "version": "11.21.3",
-            "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-openharmony-arm64/-/binding-openharmony-arm64-11.21.3.tgz",
-            "integrity": "sha512-4j1DFwjwv36ec9kds0jU/ucQ5Ha4ERO/H95BxR5JFf0kqUUAJ1kwII7XhTc1vZrkdJkvLGC9Q2MbpObpum8RBg==",
+            "version": "11.24.2",
+            "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-openharmony-arm64/-/binding-openharmony-arm64-11.24.2.tgz",
+            "integrity": "sha512-MvyGik3a6pVgZ0t/kWlbmFxFLmXQJwgLsY2eYFHLpy0wGwRbfzeIGgDwQ3kXqE30z+kSXennRkCrT7TUvkptNg==",
             "cpu": [
                 "arm64"
             ],
@@ -6001,9 +6001,9 @@
             ]
         },
         "node_modules/@oxc-resolver/binding-wasm32-wasi": {
-            "version": "11.21.3",
-            "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-wasm32-wasi/-/binding-wasm32-wasi-11.21.3.tgz",
-            "integrity": "sha512-i8oluoel5kru/j1WNrjmQSiA3GQ7wvIYVR1IwIoZtKogAhya2iub+ZKIeSIkcJOrnzQ18Tzl/F+kL3fYOxZLvA==",
+            "version": "11.24.2",
+            "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-wasm32-wasi/-/binding-wasm32-wasi-11.24.2.tgz",
+            "integrity": "sha512-vHcssMPwO08RTvj/c0iOBz90attxyG3wQJ0dTcyEQK43LRpcdLWZlV5feBhv6Isn6ahbQIzHbCgfa81+RiML0Q==",
             "cpu": [
                 "wasm32"
             ],
@@ -6011,41 +6011,18 @@
             "license": "MIT",
             "optional": true,
             "dependencies": {
-                "@emnapi/core": "1.11.0",
-                "@emnapi/runtime": "1.11.0",
-                "@napi-rs/wasm-runtime": "^1.1.5"
+                "@emnapi/core": "1.11.2",
+                "@emnapi/runtime": "1.11.2",
+                "@napi-rs/wasm-runtime": "^1.1.6"
             },
             "engines": {
                 "node": ">=14.0.0"
             }
         },
-        "node_modules/@oxc-resolver/binding-wasm32-wasi/node_modules/@emnapi/core": {
-            "version": "1.11.0",
-            "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.11.0.tgz",
-            "integrity": "sha512-l9Oo58x0HOP5znGzVhYW9U3e5wVuA4LAZU2AGezTmkhO1CgQRFDhDg4nneHsu/t3WniXg9QrG2nIXL/ZS8ln8Q==",
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "dependencies": {
-                "@emnapi/wasi-threads": "1.2.2",
-                "tslib": "^2.4.0"
-            }
-        },
-        "node_modules/@oxc-resolver/binding-wasm32-wasi/node_modules/@emnapi/runtime": {
-            "version": "1.11.0",
-            "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.0.tgz",
-            "integrity": "sha512-55coeOFKHv1ywEcUXJtWU5f+Jr/W5tZDvZig8DLKSwUN1JpROQ4rk/SNOQiFWmaR/VKF4zuFyW1B8JduOSv6Pg==",
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "dependencies": {
-                "tslib": "^2.4.0"
-            }
-        },
         "node_modules/@oxc-resolver/binding-win32-arm64-msvc": {
-            "version": "11.21.3",
-            "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-11.21.3.tgz",
-            "integrity": "sha512-M/8dw8dD6aOs+NlPJax401CZB9I7Aut84isQLgALGGwke4Afvw+/7yYhZb94yXf6t2sPLhQLmSmtSV+2FhsOWg==",
+            "version": "11.24.2",
+            "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-11.24.2.tgz",
+            "integrity": "sha512-uokJqro2iBqkFvJdKQLP7d8/BUmFwESQFVmIJUQKj1Xn1a/LysJoe1vmeECLF5b3jsV8CAL5sEMJXX6SdK9Nhg==",
             "cpu": [
                 "arm64"
             ],
@@ -6057,9 +6034,9 @@
             ]
         },
         "node_modules/@oxc-resolver/binding-win32-x64-msvc": {
-            "version": "11.21.3",
-            "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-win32-x64-msvc/-/binding-win32-x64-msvc-11.21.3.tgz",
-            "integrity": "sha512-H7BCt/VnS9hnmMp42eGhZ99izSCRvlnWwy/N71K1/J8QoExwY4262Z8QiEkMDtduRJrztayDxETTckmUuAVL9Q==",
+            "version": "11.24.2",
+            "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-win32-x64-msvc/-/binding-win32-x64-msvc-11.24.2.tgz",
+            "integrity": "sha512-UqGPmo56KDfLlfXFAFIrNflHT8tFxWGEivWg3Zeyp4Uy2NlKN1FGPr6/BxcLGG3+kZ6Wp14g5Uj+n71boqZfiw==",
             "cpu": [
                 "x64"
             ],
@@ -15124,9 +15101,9 @@
             }
         },
         "node_modules/knip": {
-            "version": "6.27.0",
-            "resolved": "https://registry.npmjs.org/knip/-/knip-6.27.0.tgz",
-            "integrity": "sha512-CngYEYrD0n20N06FXA8n3u/0Wnnugoa+B9k14OP+iKIgkCHuzvIdsP3nfwjhByoc1WfogpxfiriMboAXFETDUw==",
+            "version": "6.29.0",
+            "resolved": "https://registry.npmjs.org/knip/-/knip-6.29.0.tgz",
+            "integrity": "sha512-A3kXqSBky1tWBAqiU9srdtu0Larhzkuyor0aD/gg+ToiqyBncCCs2Q60sLsxmcKhV0OsKss9LV0hMPpwLv711Q==",
             "dev": true,
             "funding": [
                 {
@@ -15144,15 +15121,15 @@
                 "formatly": "^0.3.0",
                 "get-tsconfig": "4.14.0",
                 "jiti": "^2.7.0",
-                "oxc-parser": "^0.137.0",
-                "oxc-resolver": "11.21.3",
-                "picomatch": "^4.0.4",
-                "smol-toml": "^1.6.1",
+                "oxc-parser": "^0.140.0",
+                "oxc-resolver": "11.24.2",
+                "picomatch": "^4.0.5",
+                "smol-toml": "^1.7.0",
                 "strip-json-comments": "5.0.3",
                 "tinyglobby": "^0.2.17",
-                "unbash": "^4.0.1",
+                "unbash": "^4.0.3",
                 "yaml": "^2.9.0",
-                "zod": "^4.1.11"
+                "zod": "^4.4.3"
             },
             "bin": {
                 "knip": "bin/knip.js",
@@ -15191,9 +15168,9 @@
             }
         },
         "node_modules/knip/node_modules/picomatch": {
-            "version": "4.0.4",
-            "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
-            "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+            "version": "4.0.5",
+            "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
+            "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -18824,13 +18801,13 @@
             }
         },
         "node_modules/oxc-parser": {
-            "version": "0.137.0",
-            "resolved": "https://registry.npmjs.org/oxc-parser/-/oxc-parser-0.137.0.tgz",
-            "integrity": "sha512-yFImD+WLElJpLKy8llG1qe4DCmMsL18peRp8XP1JKfig/gISbJkglnpDtX2aTmAn10kZF7164HbN2H8QPsXxGg==",
+            "version": "0.140.0",
+            "resolved": "https://registry.npmjs.org/oxc-parser/-/oxc-parser-0.140.0.tgz",
+            "integrity": "sha512-h6QFWd6lBMfjESqgQ27GjzrSDb0qbznp7VDQqp2zvgsrWut4vcchyMIzOVXvGQ2GMZgKw9RWrFNWv9WqGL0p7Q==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@oxc-project/types": "^0.137.0"
+                "@oxc-project/types": "^0.140.0"
             },
             "engines": {
                 "node": "^20.19.0 || >=22.12.0"
@@ -18839,57 +18816,57 @@
                 "url": "https://github.com/sponsors/Boshen"
             },
             "optionalDependencies": {
-                "@oxc-parser/binding-android-arm-eabi": "0.137.0",
-                "@oxc-parser/binding-android-arm64": "0.137.0",
-                "@oxc-parser/binding-darwin-arm64": "0.137.0",
-                "@oxc-parser/binding-darwin-x64": "0.137.0",
-                "@oxc-parser/binding-freebsd-x64": "0.137.0",
-                "@oxc-parser/binding-linux-arm-gnueabihf": "0.137.0",
-                "@oxc-parser/binding-linux-arm-musleabihf": "0.137.0",
-                "@oxc-parser/binding-linux-arm64-gnu": "0.137.0",
-                "@oxc-parser/binding-linux-arm64-musl": "0.137.0",
-                "@oxc-parser/binding-linux-ppc64-gnu": "0.137.0",
-                "@oxc-parser/binding-linux-riscv64-gnu": "0.137.0",
-                "@oxc-parser/binding-linux-riscv64-musl": "0.137.0",
-                "@oxc-parser/binding-linux-s390x-gnu": "0.137.0",
-                "@oxc-parser/binding-linux-x64-gnu": "0.137.0",
-                "@oxc-parser/binding-linux-x64-musl": "0.137.0",
-                "@oxc-parser/binding-openharmony-arm64": "0.137.0",
-                "@oxc-parser/binding-wasm32-wasi": "0.137.0",
-                "@oxc-parser/binding-win32-arm64-msvc": "0.137.0",
-                "@oxc-parser/binding-win32-ia32-msvc": "0.137.0",
-                "@oxc-parser/binding-win32-x64-msvc": "0.137.0"
+                "@oxc-parser/binding-android-arm-eabi": "0.140.0",
+                "@oxc-parser/binding-android-arm64": "0.140.0",
+                "@oxc-parser/binding-darwin-arm64": "0.140.0",
+                "@oxc-parser/binding-darwin-x64": "0.140.0",
+                "@oxc-parser/binding-freebsd-x64": "0.140.0",
+                "@oxc-parser/binding-linux-arm-gnueabihf": "0.140.0",
+                "@oxc-parser/binding-linux-arm-musleabihf": "0.140.0",
+                "@oxc-parser/binding-linux-arm64-gnu": "0.140.0",
+                "@oxc-parser/binding-linux-arm64-musl": "0.140.0",
+                "@oxc-parser/binding-linux-ppc64-gnu": "0.140.0",
+                "@oxc-parser/binding-linux-riscv64-gnu": "0.140.0",
+                "@oxc-parser/binding-linux-riscv64-musl": "0.140.0",
+                "@oxc-parser/binding-linux-s390x-gnu": "0.140.0",
+                "@oxc-parser/binding-linux-x64-gnu": "0.140.0",
+                "@oxc-parser/binding-linux-x64-musl": "0.140.0",
+                "@oxc-parser/binding-openharmony-arm64": "0.140.0",
+                "@oxc-parser/binding-wasm32-wasi": "0.140.0",
+                "@oxc-parser/binding-win32-arm64-msvc": "0.140.0",
+                "@oxc-parser/binding-win32-ia32-msvc": "0.140.0",
+                "@oxc-parser/binding-win32-x64-msvc": "0.140.0"
             }
         },
         "node_modules/oxc-resolver": {
-            "version": "11.21.3",
-            "resolved": "https://registry.npmjs.org/oxc-resolver/-/oxc-resolver-11.21.3.tgz",
-            "integrity": "sha512-2Mx3fKQz7+xgrBONjsxOgCGtMHOn38/HxMzW1I5efwXB5a4lRN0Vp40gYUJFBWJslcrvwoofTrqoTnLbwTd3pA==",
+            "version": "11.24.2",
+            "resolved": "https://registry.npmjs.org/oxc-resolver/-/oxc-resolver-11.24.2.tgz",
+            "integrity": "sha512-FY91FiDBj7ls5MsFS9jN3tjz2o0/zsdSsymlakySaBwVJZorHhkWyICLZMKxlu1R9vYo+sd3z1jwb4J8x7bNDw==",
             "dev": true,
             "license": "MIT",
             "funding": {
                 "url": "https://github.com/sponsors/Boshen"
             },
             "optionalDependencies": {
-                "@oxc-resolver/binding-android-arm-eabi": "11.21.3",
-                "@oxc-resolver/binding-android-arm64": "11.21.3",
-                "@oxc-resolver/binding-darwin-arm64": "11.21.3",
-                "@oxc-resolver/binding-darwin-x64": "11.21.3",
-                "@oxc-resolver/binding-freebsd-x64": "11.21.3",
-                "@oxc-resolver/binding-linux-arm-gnueabihf": "11.21.3",
-                "@oxc-resolver/binding-linux-arm-musleabihf": "11.21.3",
-                "@oxc-resolver/binding-linux-arm64-gnu": "11.21.3",
-                "@oxc-resolver/binding-linux-arm64-musl": "11.21.3",
-                "@oxc-resolver/binding-linux-ppc64-gnu": "11.21.3",
-                "@oxc-resolver/binding-linux-riscv64-gnu": "11.21.3",
-                "@oxc-resolver/binding-linux-riscv64-musl": "11.21.3",
-                "@oxc-resolver/binding-linux-s390x-gnu": "11.21.3",
-                "@oxc-resolver/binding-linux-x64-gnu": "11.21.3",
-                "@oxc-resolver/binding-linux-x64-musl": "11.21.3",
-                "@oxc-resolver/binding-openharmony-arm64": "11.21.3",
-                "@oxc-resolver/binding-wasm32-wasi": "11.21.3",
-                "@oxc-resolver/binding-win32-arm64-msvc": "11.21.3",
-                "@oxc-resolver/binding-win32-x64-msvc": "11.21.3"
+                "@oxc-resolver/binding-android-arm-eabi": "11.24.2",
+                "@oxc-resolver/binding-android-arm64": "11.24.2",
+                "@oxc-resolver/binding-darwin-arm64": "11.24.2",
+                "@oxc-resolver/binding-darwin-x64": "11.24.2",
+                "@oxc-resolver/binding-freebsd-x64": "11.24.2",
+                "@oxc-resolver/binding-linux-arm-gnueabihf": "11.24.2",
+                "@oxc-resolver/binding-linux-arm-musleabihf": "11.24.2",
+                "@oxc-resolver/binding-linux-arm64-gnu": "11.24.2",
+                "@oxc-resolver/binding-linux-arm64-musl": "11.24.2",
+                "@oxc-resolver/binding-linux-ppc64-gnu": "11.24.2",
+                "@oxc-resolver/binding-linux-riscv64-gnu": "11.24.2",
+                "@oxc-resolver/binding-linux-riscv64-musl": "11.24.2",
+                "@oxc-resolver/binding-linux-s390x-gnu": "11.24.2",
+                "@oxc-resolver/binding-linux-x64-gnu": "11.24.2",
+                "@oxc-resolver/binding-linux-x64-musl": "11.24.2",
+                "@oxc-resolver/binding-openharmony-arm64": "11.24.2",
+                "@oxc-resolver/binding-wasm32-wasi": "11.24.2",
+                "@oxc-resolver/binding-win32-arm64-msvc": "11.24.2",
+                "@oxc-resolver/binding-win32-x64-msvc": "11.24.2"
             }
         },
         "node_modules/p-cancelable": {
@@ -23284,9 +23261,9 @@
             }
         },
         "node_modules/smol-toml": {
-            "version": "1.6.1",
-            "resolved": "https://registry.npmjs.org/smol-toml/-/smol-toml-1.6.1.tgz",
-            "integrity": "sha512-dWUG8F5sIIARXih1DTaQAX4SsiTXhInKf1buxdY9DIg4ZYPZK5nGM1VRIYmEbDbsHt7USo99xSLFu5Q1IqTmsg==",
+            "version": "1.7.0",
+            "resolved": "https://registry.npmjs.org/smol-toml/-/smol-toml-1.7.0.tgz",
+            "integrity": "sha512-aqVvWoyO21L23mb+drl4RmMXbf6N7FdHjAhTRA9ZBL7apWBgfWC16KjrASI+1p9GAroljyMHj6fK67i0UiTNvQ==",
             "dev": true,
             "license": "BSD-3-Clause",
             "engines": {
@@ -24498,9 +24475,9 @@
             }
         },
         "node_modules/unbash": {
-            "version": "4.0.1",
-            "resolved": "https://registry.npmjs.org/unbash/-/unbash-4.0.1.tgz",
-            "integrity": "sha512-1ajSo3813sDoVIHx4inJdUS4l5L2ic5cFiddemPiyjb/PZEoBAhFwHtbaEdRDFxbAKy7FCG7s5ww3/uCFawuIA==",
+            "version": "4.0.3",
+            "resolved": "https://registry.npmjs.org/unbash/-/unbash-4.0.3.tgz",
+            "integrity": "sha512-3cudTErfToSc4Ggv8XGXVNVli/xHKUtUZvaY5UVwhOcUPbQGz7PeaEnT/SAVgNziZtX67KEN9swMUYkLghxA1w==",
             "dev": true,
             "license": "ISC",
             "engines": {

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
         "eslint": "^9.39.3",
         "eslint-plugin-markdownlint": "^0.10.1",
         "eslint-plugin-react": "^7.37.5",
-        "knip": "^6.27.0",
+        "knip": "^6.29.0",
         "lucide-react": "^1.26.0",
         "postcss": "^8.5.23",
         "prettier": "^3.9.6",


### PR DESCRIPTION
Fixes PR #797 (knip 6.27.0 → 6.29.0 Dependabot bump).

The original PR #797 failed at package-lock-utd because of CI vs local environment differences:
- CI runs Node.js 22 (ubuntu-latest) with npm 10.9.8
- Local runs Node.js 20 (macOS) with npm 10.8.2
- Dependabot generated lockfile on a different npm environment than CI's package-lock-utd regenerates

This PR regenerates the lockfile with the current npm, ensuring consistency with CI's package-lock-utd validation step.